### PR TITLE
Align fallback otag and partner mappings

### DIFF
--- a/supabase/functions/semantic-search/index.ts
+++ b/supabase/functions/semantic-search/index.ts
@@ -2251,11 +2251,11 @@ Remember: Return ONLY the Scryfall query. No explanations. No card suggestions.`
         [/\brituals?\b/gi, 'otag:ritual'],
         
         // Card advantage - use otag
-        [/\bcard draw\b/gi, 'otag:draw'],
-        [/\bdraw cards?\b/gi, 'otag:draw'],
+        [/\bcard draw\b/gi, 'otag:card-draw'],
+        [/\bdraw cards?\b/gi, 'otag:card-draw'],
         [/\bcantrips?\b/gi, 'otag:cantrip'],
-        [/\blooting\b/gi, 'otag:loot'],
-        [/\bloot effects?\b/gi, 'otag:loot'],
+        [/\blooting\b/gi, 'otag:looting'],
+        [/\bloot effects?\b/gi, 'otag:looting'],
         [/\bwheels?\b/gi, 'otag:wheel'],
         [/\bwheel effects?\b/gi, 'otag:wheel'],
         [/\bimpulse draw\b/gi, 'otag:impulse-draw'],
@@ -2544,7 +2544,7 @@ Remember: Return ONLY the Scryfall query. No explanations. No card suggestions.`
         [/\breprints? only\b/gi, 'is:reprint'],
         
         // Commander mechanics
-        [/\bpartner commanders?\b/gi, 't:legendary t:creature o:"partner"'],
+        [/\bpartner commanders?\b/gi, 'is:commander is:partner'],
         [/\bbackgrounds?\b/gi, 't:background'],
         [/\bchoose a background\b/gi, 'o:"choose a background"'],
         [/\bcompanions?\b/gi, 'is:companion'],


### PR DESCRIPTION
### Motivation
- Normalize fallback search transforms to use consistent `otag` names for card-advantage terms to improve query mapping accuracy.
- Use explicit commander filters for partner commanders so natural-language queries map to the intended Scryfall syntax.

### Description
- Updated `supabase/functions/semantic-search/index.ts` to replace `otag:draw` with `otag:card-draw` for card-draw fallbacks.
- Replaced `otag:loot` with `otag:looting` for looting-related fallbacks in the same file.
- Changed the partner commander fallback mapping from `t:legendary t:creature o:"partner"` to `is:commander is:partner`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961de8a0670833081388d3a510d0b2b)