### PR TITLE
Add Vitest test script and devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -79,6 +80,7 @@
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^2.1.9"
   }
 }


### PR DESCRIPTION
### Motivation
- Enable running unit tests in this Vite + React + TypeScript project by adding Vitest integration.
- Provide a standard `test` npm script so CI and contributors can run tests with a single command.

### Description
- Updated `package.json` to add a `"test": "vitest"` script under `scripts`.
- Added `vitest` (version `^2.1.9`) to `devDependencies` in `package.json`.
- No test files or other source changes were added in this change; only `package.json` was modified.

### Testing
- No automated tests were executed because dependency installation was blocked in the environment.
- Attempting `npm install -D vitest` failed with a `403 Forbidden` from the npm registry, preventing installation.
- Attempting `bun add -d vitest` also failed with registry `403` errors for multiple packages, so `vitest` could not be installed and run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961e1bd8cd0833098e2d440402249bb)