### PR TITLE
Always-show editable compiled query + deterministic pre-parser and safer search flow

### DIFF
--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -62,18 +62,6 @@ export const CardItem = memo(function CardItem({ card, onClick }: CardItemProps)
         </div>
       </div>
       
-      {/* Rarity indicator */}
-      <div 
-        className={cn(
-          "absolute top-2.5 right-2.5 h-2 w-2 rounded-full transition-all duration-300",
-          card.rarity === "mythic" && "bg-orange-400 shadow-[0_0_8px_2px] shadow-orange-400/50",
-          card.rarity === "rare" && "bg-amber-400 shadow-[0_0_8px_2px] shadow-amber-400/40",
-          card.rarity === "uncommon" && "bg-slate-300",
-          card.rarity === "common" && "bg-slate-500"
-        )}
-        aria-hidden="true"
-      />
-
       {/* Hover border */}
       <div 
         className="absolute inset-0 rounded-xl border border-white/0 group-hover:border-white/15 transition-colors duration-300" 

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -70,9 +70,10 @@ interface SearchFiltersProps {
   cards: ScryfallCard[];
   onFilteredCards: (cards: ScryfallCard[], hasActiveFilters: boolean) => void;
   totalCards: number;
+  onFiltersChange?: (filters: FilterState) => void;
 }
 
-export function SearchFilters({ cards, onFilteredCards, totalCards }: SearchFiltersProps) {
+export function SearchFilters({ cards, onFilteredCards, totalCards, onFiltersChange }: SearchFiltersProps) {
   const [filters, setFilters] = useState<FilterState>({
     colors: [],
     types: [],
@@ -162,6 +163,10 @@ export function SearchFilters({ cards, onFilteredCards, totalCards }: SearchFilt
   useEffect(() => {
     onFilteredCards(filteredCards, hasActiveFilters);
   }, [filteredCards, hasActiveFilters, onFilteredCards]);
+
+  useEffect(() => {
+    onFiltersChange?.(filters);
+  }, [filters, onFiltersChange]);
 
   const toggleColor = useCallback((colorId: string) => {
     setFilters(prev => ({

--- a/src/components/SearchHelpModal.tsx
+++ b/src/components/SearchHelpModal.tsx
@@ -57,7 +57,7 @@ const EXAMPLE_QUERIES = [
     icon: Mountain,
     examples: [
       { query: "artifacts that produce 2 mana", description: "Mana rocks with high output" },
-      { query: "red or black creatures under 3 mana", description: "Cheap Rakdos-only creatures" },
+      { query: "red or black creatures under 3 mana", description: "Red or black creatures under 3 mana" },
       { query: "lands that produce any color", description: "Five-color mana fixing" },
       { query: "mana dorks that cost 1", description: "One-mana creature ramp" },
     ]

--- a/src/components/UnifiedSearchBar.tsx
+++ b/src/components/UnifiedSearchBar.tsx
@@ -7,66 +7,14 @@ import { useState, useRef, useCallback, useImperativeHandle, forwardRef, useEffe
 import { Button } from '@/components/ui/button';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
-import { Search, Loader2, X, ArrowRight, History, Clock } from 'lucide-react';
+import { Search, Loader2, X, ArrowRight, History, Clock, RotateCcw } from 'lucide-react';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { SearchFeedback } from '@/components/SearchFeedback';
 import { SearchHelpModal } from '@/components/SearchHelpModal';
 
 const SEARCH_CONTEXT_KEY = 'lastSearchContext';
 const SEARCH_HISTORY_KEY = 'offmeta_search_history';
-const RESULT_CACHE_KEY = 'offmeta_result_cache_v2'; // Bump version to invalidate old caches
 const MAX_HISTORY_ITEMS = 5;
 const SEARCH_TIMEOUT_MS = 15000; // 15 second timeout
-const RESULT_CACHE_TTL = 30 * 60 * 1000; // 30 minute cache for results (cost optimization)
-const MAX_CACHE_SIZE = 50;
-
-// Client-side result caching to prevent duplicate edge function calls
-interface CachedResult {
-  scryfallQuery: string;
-  explanation?: {
-    readable: string;
-    assumptions: string[];
-    confidence: number;
-  };
-  showAffiliate?: boolean;
-  timestamp: number;
-}
-
-function normalizeQueryKey(query: string): string {
-  return query.toLowerCase().trim().replace(/\s+/g, ' ');
-}
-
-function getCachedResult(query: string): CachedResult | null {
-  try {
-    const cache = JSON.parse(sessionStorage.getItem(RESULT_CACHE_KEY) || '{}');
-    const key = normalizeQueryKey(query);
-    const cached = cache[key];
-    if (cached && Date.now() - cached.timestamp < RESULT_CACHE_TTL) {
-      return cached;
-    }
-    // Clean up expired entry
-    if (cached) {
-      delete cache[key];
-      sessionStorage.setItem(RESULT_CACHE_KEY, JSON.stringify(cache));
-    }
-  } catch {}
-  return null;
-}
-
-function setCachedResult(query: string, result: Omit<CachedResult, 'timestamp'>): void {
-  try {
-    const cache = JSON.parse(sessionStorage.getItem(RESULT_CACHE_KEY) || '{}');
-    const key = normalizeQueryKey(query);
-    cache[key] = { ...result, timestamp: Date.now() };
-    // Limit cache size - remove oldest entries
-    const keys = Object.keys(cache);
-    if (keys.length > MAX_CACHE_SIZE) {
-      const sorted = keys.sort((a, b) => cache[a].timestamp - cache[b].timestamp);
-      sorted.slice(0, keys.length - MAX_CACHE_SIZE).forEach(k => delete cache[k]);
-    }
-    sessionStorage.setItem(RESULT_CACHE_KEY, JSON.stringify(cache));
-  } catch {}
-}
 
 interface SearchContext {
   previousQuery: string;
@@ -129,13 +77,20 @@ export interface SearchResult {
     assumptions: string[];
     confidence: number;
   };
+  lintIssues?: string[];
+  notes?: string[];
+  intentBreakdown?: {
+    label: string;
+    tokens: string[];
+    detail?: string;
+  }[];
   showAffiliate?: boolean;
 }
 
 interface UnifiedSearchBarProps {
-  onSearch: (query: string, result?: SearchResult, naturalQuery?: string) => void;
+  onSearchStart: (query: string, requestId: string) => void;
+  onSearch: (query: string, result: SearchResult | undefined, naturalQuery: string, requestId: string) => void;
   isLoading: boolean;
-  lastTranslatedQuery?: string;
 }
 
 export interface UnifiedSearchBarHandle {
@@ -152,16 +107,17 @@ const EXAMPLE_QUERIES = [
 ];
 
 export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearchBarProps>(
-  function UnifiedSearchBar({ onSearch, isLoading, lastTranslatedQuery }, ref) {
+  function UnifiedSearchBar({ onSearchStart, onSearch, isLoading }, ref) {
   const isMobile = useIsMobile();
   const [query, setQuery] = useState('');
   const [isSearching, setIsSearching] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [rateLimitedUntil, setRateLimitedUntil] = useState<number | null>(null);
   const [rateLimitCountdown, setRateLimitCountdown] = useState<number>(0);
+  const [useLastContext, setUseLastContext] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const lastSearchRef = useRef<string>('');
   const abortControllerRef = useRef<AbortController | null>(null);
+  const requestIdRef = useRef<string | null>(null);
   const { saveContext, getContext } = useSearchContext();
   const { history, addToHistory, clearHistory } = useSearchHistory();
 
@@ -187,44 +143,30 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
     return () => clearInterval(interval);
   }, [rateLimitedUntil]);
 
-  useImperativeHandle(ref, () => ({
-    triggerSearch: (searchQuery: string) => {
-      setQuery(searchQuery);
-      handleSearch(searchQuery);
+  const createRequestId = () => {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+      return crypto.randomUUID();
     }
-  }), []);
+    return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  };
 
   const handleSearch = async (searchQuery?: string) => {
     const queryToSearch = (searchQuery || query).trim();
     
     // Prevent empty, duplicate, or rate-limited searches
     if (!queryToSearch) return;
-    if (queryToSearch === lastSearchRef.current && !searchQuery) return;
     if (rateLimitedUntil && Date.now() < rateLimitedUntil) {
       toast.error('Please wait', {
         description: `Rate limited. Try again in ${rateLimitCountdown}s`
       });
       return;
     }
-    
-    lastSearchRef.current = queryToSearch;
+
+    const requestId = createRequestId();
+    requestIdRef.current = requestId;
     addToHistory(queryToSearch);
-    
-    // Check client-side cache first (eliminates edge function call entirely)
-    const cached = getCachedResult(queryToSearch);
-    if (cached) {
-      console.log('[Cache] Client-side hit for:', queryToSearch);
-      saveContext(queryToSearch, cached.scryfallQuery);
-      onSearch(cached.scryfallQuery, {
-        scryfallQuery: cached.scryfallQuery,
-        explanation: cached.explanation,
-        showAffiliate: cached.showAffiliate
-      }, queryToSearch); // Pass natural language query
-      toast.success('Search (cached)', {
-        description: `Found: ${cached.scryfallQuery.substring(0, 50)}${cached.scryfallQuery.length > 50 ? '...' : ''}`
-      });
-      return;
-    }
+
+    onSearchStart(queryToSearch, requestId);
     
     // Cancel any pending request
     if (abortControllerRef.current) {
@@ -240,12 +182,14 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
     });
 
     try {
-      const context = getContext();
+      const context = useLastContext ? getContext() : null;
       
       const searchPromise = supabase.functions.invoke('semantic-search', {
         body: {
           query: queryToSearch,
-          context: context || undefined
+          context: context || undefined,
+          allowCache: useLastContext,
+          requestId
         }
       });
       
@@ -264,21 +208,21 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
         return;
       }
 
+      if (requestIdRef.current !== requestId) {
+        return;
+      }
+
       if (data?.success && data?.scryfallQuery) {
         saveContext(queryToSearch, data.scryfallQuery);
-        
-        // Cache the result client-side for 15 minutes
-        setCachedResult(queryToSearch, {
-          scryfallQuery: data.scryfallQuery,
-          explanation: data.explanation,
-          showAffiliate: data.showAffiliate
-        });
         
         onSearch(data.scryfallQuery, {
           scryfallQuery: data.scryfallQuery,
           explanation: data.explanation,
-          showAffiliate: data.showAffiliate
-        }, queryToSearch); // Pass natural language query
+          showAffiliate: data.showAffiliate,
+          lintIssues: data.lintIssues,
+          notes: data.notes,
+          intentBreakdown: data.intentBreakdown
+        }, queryToSearch, requestId); // Pass natural language query
         
         const source = data.source || 'ai';
         toast.success(`Search translated${source !== 'ai' ? ` (${source})` : ''}`, {
@@ -288,6 +232,9 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
         throw new Error(data?.error || 'Failed to translate');
       }
     } catch (error: unknown) {
+      if (requestIdRef.current !== requestId) {
+        return;
+      }
       // Handle different error types
       const errorMessage = error instanceof Error ? error.message : String(error);
       
@@ -296,7 +243,7 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
         toast.error('Search took too long', {
           description: 'Try a simpler query or try again'
         });
-        onSearch(queryToSearch, undefined, queryToSearch); // Fall back to direct search
+        onSearch(queryToSearch, undefined, queryToSearch, requestId); // Fall back to direct search
       } else if (errorMessage.includes('429') || errorMessage.includes('rate')) {
         setRateLimitedUntil(Date.now() + 30000);
         toast.error('Too many searches', {
@@ -307,13 +254,23 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
         toast.error('Search issue', {
           description: 'Trying direct search instead'
         });
-        onSearch(queryToSearch, undefined, queryToSearch);
+        onSearch(queryToSearch, undefined, queryToSearch, requestId);
       }
     } finally {
-      setIsSearching(false);
+      if (requestIdRef.current === requestId) {
+        setIsSearching(false);
+        setUseLastContext(false);
+      }
       abortControllerRef.current = null;
     }
   };
+
+  useImperativeHandle(ref, () => ({
+    triggerSearch: (searchQuery: string) => {
+      setQuery(searchQuery);
+      handleSearch(searchQuery);
+    }
+  }), [handleSearch]);
 
   const showExamples = !query;
 
@@ -394,15 +351,20 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
               </>
             )}
           </Button>
+
+          <Button
+            onClick={() => setUseLastContext(prev => !prev)}
+            variant={useLastContext ? "secondary" : "ghost"}
+            size="sm"
+            className="h-8 sm:h-10 px-2 sm:px-3 rounded-lg gap-1 text-xs sm:text-sm flex-shrink-0"
+            aria-pressed={useLastContext}
+            title="Reuse last interpretation on the next search"
+          >
+            <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+            <span className="hidden sm:inline">Use last</span>
+          </Button>
           
           {/* Feedback button - visible on all sizes */}
-          <div className="flex-shrink-0">
-            <SearchFeedback 
-              originalQuery={query || history[0] || ''} 
-              translatedQuery={lastTranslatedQuery} 
-            />
-          </div>
-          
           {/* Help modal - desktop only */}
           <div className="hidden sm:block flex-shrink-0">
             <SearchHelpModal 

--- a/src/lib/scryfallQuery.ts
+++ b/src/lib/scryfallQuery.ts
@@ -1,0 +1,64 @@
+const VALID_SEARCH_KEYS = new Set([
+  'c', 'color', 'id', 'identity', 'o', 'oracle', 't', 'type',
+  'm', 'mana', 'cmc', 'mv', 'manavalue',
+  'power', 'pow', 'toughness', 'tou', 'loyalty', 'loy',
+  'e', 'set', 's', 'b', 'block', 'r', 'rarity',
+  'f', 'format', 'legal', 'banned', 'restricted',
+  'is', 'not', 'has',
+  'usd', 'eur', 'tix',
+  'a', 'artist', 'ft', 'flavor',
+  'wm', 'watermark', 'border', 'frame', 'game',
+  'year', 'date', 'new', 'prints', 'lang', 'in',
+  'st', 'cube', 'order', 'direction', 'unique', 'prefer', 'include',
+  'produces', 'devotion', 'name',
+  'otag', 'oracletag', 'function',
+  'atag', 'arttag',
+]);
+
+export function normalizeBooleanPrecedence(query: string): string {
+  return query.replace(/(\S+\s+OR\s+\S+(?:\s+OR\s+\S+)*)/gi, '($1)');
+}
+
+export function validateScryfallQuery(query: string): { sanitized: string; issues: string[] } {
+  const issues: string[] = [];
+  let sanitized = query.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+
+  if (!sanitized) {
+    return { sanitized: '', issues: ['Query is empty'] };
+  }
+
+  const keyPattern = /\b([a-zA-Z]+)[:=<>]/g;
+  const unknownKeys: string[] = [];
+  let keyMatch;
+  while ((keyMatch = keyPattern.exec(sanitized)) !== null) {
+    const key = keyMatch[1].toLowerCase();
+    if (!VALID_SEARCH_KEYS.has(key)) {
+      unknownKeys.push(key);
+    }
+  }
+  if (unknownKeys.length > 0) {
+    issues.push(`Unknown search key(s): ${unknownKeys.join(', ')}`);
+  }
+
+  let parenCount = 0;
+  for (const char of sanitized) {
+    if (char === '(') parenCount++;
+    if (char === ')') parenCount--;
+    if (parenCount < 0) break;
+  }
+  if (parenCount !== 0) {
+    issues.push('Unbalanced parentheses');
+  }
+
+  const doubleQuoteCount = (sanitized.match(/"/g) || []).length;
+  if (doubleQuoteCount % 2 !== 0) {
+    issues.push('Unbalanced double quotes');
+  }
+
+  const singleQuoteCount = (sanitized.match(/'/g) || []).length;
+  if (singleQuoteCount % 2 !== 0) {
+    issues.push('Unbalanced single quotes');
+  }
+
+  return { sanitized, issues };
+}


### PR DESCRIPTION
### Motivation
- Users must always see the compiled Scryfall query, be able to edit it, rerun it, and open/copy/report it without hidden clicks. 
- Searches should always run against the current prompt + current filters + any edited compiled query and must not reuse stale interpretations. 
- Improve Scryfall correctness by applying deterministic parsing rules (colors, types, numeric constraints, commander intent, years) before calling the LLM. 
- Harden boolean precedence, linting/validation and tag-first (otag) behavior so the system never emits invalid Scryfall syntax and surfaces approximations when needed. 

### Description
- UI: added an always-visible, editable compiled query panel with `Re-run`, `Copy query`, and `Open in Scryfall` controls plus a `Report issue` button that auto-includes prompt, compiled query, active filters, timestamp and request id, and removed the small glowing rarity dot overlay from `CardItem` (no overlay on card UI). 
- Client: `UnifiedSearchBar` now generates `requestId`s, cancels inflight requests, prevents stale responses from overwriting current results, exposes `onSearchStart`/`onSearch`, and adds a `Use last` toggle to optionally reuse the last interpretation; `SearchFilters` emits filter changes and `Index` clears prior result state and ties loading to the active request id. 
- Backend: `supabase/functions/semantic-search` got a deterministic pre-parser (`parseDeterministicIntent` + `buildQueryFromDeterministic`) performing color/type/mv/power/toughness/equipment/graveyard parsing, a tag-first mapping (`TAG_INTENTS`/`KNOWN_OTAGS`), cache gating (`allowCache`), boolean-normalization and linting (`validateQuery`/`lintQuery`), and it composes the AI prompt only for fuzzy parts; it also replaces invalid year `e:2021` style tokens with `year=` and returns lint issues/intent breakdown to the client. 
- Utilities: added client-side helpers `normalizeBooleanPrecedence` and `validateScryfallQuery` in `src/lib/scryfallQuery.ts`, wired lint/notes/intentBreakdown into the UI, and added a feedback form update to include auto-included metadata. 

### Testing
- Started the dev server with `npm run dev` (Vite) to exercise the UI and the server proxy and it reported the site ready (local/network URLs). 
- Ran a Playwright smoke script that loads the landing page, performs a search, and captured a screenshot of the compiled query panel to validate the end-to-end flow, which completed and produced artifacts. 
- No new unit tests were added as part of this change. 
- Manual/automated integration checks confirmed request cancellation/de-dup behavior (inflight aborts) and that deterministic-only queries bypass the AI path and return immediately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961deac6e28833084c0e6d53aaf8a18)