### PR TITLE
Deterministic intent parsing, otag validation, and explain-panel + UI improvements

### DIFF
--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -3,10 +3,12 @@
  * Memoized to prevent unnecessary re-renders in large lists.
  */
 
-import { memo } from "react";
+import { memo, KeyboardEvent, MouseEvent } from "react";
 import { ScryfallCard } from "@/types/card";
 import { getCardImage } from "@/lib/scryfall";
 import { cn } from "@/lib/utils";
+import { Copy, Link2 } from "lucide-react";
+import { toast } from "sonner";
 
 interface CardItemProps {
   card: ScryfallCard;
@@ -15,10 +17,39 @@ interface CardItemProps {
 
 export const CardItem = memo(function CardItem({ card, onClick }: CardItemProps) {
   const imageUrl = getCardImage(card, "normal");
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onClick();
+    }
+  };
+
+  const handleCopyName = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(card.name);
+      toast.success('Card name copied');
+    } catch {
+      toast.error('Failed to copy card name');
+    }
+  };
+
+  const handleCopyLink = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(card.scryfall_uri);
+      toast.success('Scryfall link copied');
+    } catch {
+      toast.error('Failed to copy Scryfall link');
+    }
+  };
 
   return (
-    <button
+    <div
       onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
       className="group relative w-full aspect-[2.5/3.5] rounded-xl overflow-hidden bg-secondary card-hover focus-ring"
       aria-label={`View details for ${card.name} from ${card.set_name}, ${card.rarity} rarity`}
     >
@@ -41,7 +72,6 @@ export const CardItem = memo(function CardItem({ card, onClick }: CardItemProps)
       {/* Card info on hover */}
       <div 
         className="absolute bottom-0 left-0 right-0 p-3 translate-y-full group-hover:translate-y-0 transition-transform duration-300 ease-out will-change-transform"
-        aria-hidden="true"
       >
         <p className="text-sm font-medium text-white truncate">
           {card.name}
@@ -60,25 +90,31 @@ export const CardItem = memo(function CardItem({ card, onClick }: CardItemProps)
             {card.rarity}
           </span>
         </div>
+        <div className="mt-2 flex gap-2">
+          <button
+            onClick={handleCopyName}
+            className="flex items-center gap-1 rounded-full bg-black/60 px-2 py-1 text-[10px] text-white hover:bg-black/80"
+            aria-label={`Copy ${card.name}`}
+          >
+            <Copy className="h-3 w-3" />
+            Copy name
+          </button>
+          <button
+            onClick={handleCopyLink}
+            className="flex items-center gap-1 rounded-full bg-black/60 px-2 py-1 text-[10px] text-white hover:bg-black/80"
+            aria-label={`Copy Scryfall link for ${card.name}`}
+          >
+            <Link2 className="h-3 w-3" />
+            Copy link
+          </button>
+        </div>
       </div>
-      
-      {/* Rarity indicator - positioned bottom-left to avoid covering mana cost */}
-      <div 
-        className={cn(
-          "absolute bottom-2.5 left-2.5 h-2 w-2 rounded-full transition-all duration-300 opacity-90 group-hover:opacity-0",
-          card.rarity === "mythic" && "bg-orange-400 shadow-[0_0_6px_1px] shadow-orange-400/40",
-          card.rarity === "rare" && "bg-amber-400 shadow-[0_0_6px_1px] shadow-amber-400/30",
-          card.rarity === "uncommon" && "bg-slate-300",
-          card.rarity === "common" && "bg-slate-500"
-        )}
-        aria-hidden="true"
-      />
 
       {/* Hover border */}
       <div 
         className="absolute inset-0 rounded-xl border border-white/0 group-hover:border-white/15 transition-colors duration-300" 
         aria-hidden="true"
       />
-    </button>
+    </div>
   );
 });

--- a/src/components/EditableQueryBar.tsx
+++ b/src/components/EditableQueryBar.tsx
@@ -9,6 +9,7 @@ import { Input } from '@/components/ui/input';
 import { toast } from 'sonner';
 import { Play, Copy, Check, ExternalLink, Edit2, AlertTriangle, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { FilterState } from '@/types/filters';
 
 interface EditableQueryBarProps {
   scryfallQuery: string;
@@ -19,7 +20,7 @@ interface EditableQueryBarProps {
   onRerun: (editedQuery: string) => void;
   onReportIssue?: () => void;
   requestId?: string;
-  filters?: Record<string, unknown>;
+  filters?: FilterState | null;
 }
 
 export const EditableQueryBar = memo(function EditableQueryBar({
@@ -182,7 +183,7 @@ export const EditableQueryBar = memo(function EditableQueryBar({
             title="Re-run query (Enter)"
           >
             <Play className="h-3.5 w-3.5" />
-            <span className="hidden sm:inline">Run</span>
+            <span className="hidden sm:inline">Re-run</span>
           </Button>
 
           <Button

--- a/src/components/ExplainCompilationPanel.tsx
+++ b/src/components/ExplainCompilationPanel.tsx
@@ -1,0 +1,87 @@
+import { SearchIntent } from '@/types/search';
+import { cn } from '@/lib/utils';
+
+interface ExplainCompilationPanelProps {
+  intent: SearchIntent | null;
+}
+
+function formatComparator(op: string, value: number): string {
+  return `${op}${value}`;
+}
+
+export function ExplainCompilationPanel({ intent }: ExplainCompilationPanelProps) {
+  if (!intent) return null;
+
+  const colorSummary = intent.colors
+    ? `${intent.colors.isIdentity ? 'id' : 'c'}${intent.colors.isExact ? '=' : ':'}${intent.colors.values.join('')}`
+    : null;
+
+  return (
+    <section className="w-full max-w-3xl mx-auto rounded-2xl border border-border bg-card/60 p-4 sm:p-5 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Explain compilation</h3>
+        {intent.deterministicQuery && (
+          <span className="text-[10px] text-muted-foreground">
+            Deterministic base: <span className="font-mono">{intent.deterministicQuery}</span>
+          </span>
+        )}
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Colors</p>
+          <p className={cn("text-sm", !colorSummary && "text-muted-foreground")}>
+            {colorSummary || 'None'}
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Types</p>
+          <p className={cn("text-sm", intent.types.length === 0 && "text-muted-foreground")}>
+            {intent.types.length ? intent.types.join(', ') : 'None'}
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Mana value</p>
+          <p className={cn("text-sm", !intent.cmc && "text-muted-foreground")}>
+            {intent.cmc ? `mv${formatComparator(intent.cmc.op, intent.cmc.value)}` : 'None'}
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Power / Toughness</p>
+          <p className={cn("text-sm", !intent.power && !intent.toughness && "text-muted-foreground")}>
+            {intent.power ? `pow${formatComparator(intent.power.op, intent.power.value)}` : '—'}
+            {intent.toughness ? `, tou${formatComparator(intent.toughness.op, intent.toughness.value)}` : ''}
+          </p>
+        </div>
+
+        <div className="space-y-1 sm:col-span-2">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Tags</p>
+          <p className={cn("text-sm", intent.tags.length === 0 && "text-muted-foreground")}>
+            {intent.tags.length ? intent.tags.join(', ') : 'None'}
+          </p>
+        </div>
+
+        <div className="space-y-1 sm:col-span-2">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Oracle fallback</p>
+          <p className={cn("text-sm font-mono break-words", intent.oraclePatterns.length === 0 && "text-muted-foreground")}>
+            {intent.oraclePatterns.length ? intent.oraclePatterns.join(' ') : 'None'}
+          </p>
+        </div>
+      </div>
+
+      {intent.warnings.length > 0 && (
+        <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-xs text-amber-700 dark:text-amber-400">
+          <p className="font-semibold">Notes</p>
+          <ul className="mt-1 list-disc pl-4 space-y-1">
+            {intent.warnings.map((warning, index) => (
+              <li key={`${warning}-${index}`}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/ReportIssueDialog.tsx
+++ b/src/components/ReportIssueDialog.tsx
@@ -22,13 +22,14 @@ import { toast } from 'sonner';
 import { Loader2, Copy, Check, ChevronDown, ChevronUp } from 'lucide-react';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import { z } from 'zod';
+import { FilterState } from '@/types/filters';
 
 interface ReportIssueDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   originalQuery: string;
   compiledQuery: string;
-  filters?: Record<string, unknown>;
+  filters?: FilterState | null;
   requestId?: string;
 }
 

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -20,6 +20,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { ScryfallCard } from '@/types/card';
+import { FilterState } from '@/types/filters';
 import { cn } from '@/lib/utils';
 import { Filter, ArrowUpDown, X, ChevronDown } from 'lucide-react';
 
@@ -59,16 +60,9 @@ const SORT_OPTIONS = [
 
 const RARITY_ORDER = { common: 0, uncommon: 1, rare: 2, mythic: 3, special: 4, bonus: 5 };
 
-export interface FilterState {
-  colors: string[];
-  types: string[];
-  cmcRange: [number, number];
-  sortBy: string;
-}
-
 interface SearchFiltersProps {
   cards: ScryfallCard[];
-  onFilteredCards: (cards: ScryfallCard[], hasActiveFilters: boolean) => void;
+  onFilteredCards: (cards: ScryfallCard[], hasActiveFilters: boolean, filters: FilterState) => void;
   totalCards: number;
 }
 
@@ -160,7 +154,7 @@ export function SearchFilters({ cards, onFilteredCards, totalCards }: SearchFilt
 
   // Notify parent of filtered results - use useEffect instead of useMemo for side effects
   useEffect(() => {
-    onFilteredCards(filteredCards, hasActiveFilters);
+    onFilteredCards(filteredCards, hasActiveFilters, filters);
   }, [filteredCards, hasActiveFilters, onFilteredCards]);
 
   const toggleColor = useCallback((colorId: string) => {

--- a/src/lib/scryfallQuery.ts
+++ b/src/lib/scryfallQuery.ts
@@ -1,0 +1,191 @@
+import { FilterState } from '@/types/filters';
+
+const VALID_SEARCH_KEYS = new Set([
+  'c', 'color', 'id', 'identity', 'o', 'oracle', 't', 'type',
+  'm', 'mana', 'cmc', 'mv', 'manavalue',
+  'power', 'pow', 'toughness', 'tou', 'loyalty', 'loy',
+  'e', 'set', 's', 'b', 'block', 'r', 'rarity',
+  'f', 'format', 'legal', 'banned', 'restricted',
+  'is', 'not', 'has',
+  'usd', 'eur', 'tix',
+  'a', 'artist', 'ft', 'flavor',
+  'wm', 'watermark', 'border', 'frame', 'game',
+  'year', 'date', 'new', 'prints', 'lang', 'in',
+  'st', 'cube', 'order', 'direction', 'unique', 'prefer', 'include',
+  'produces', 'devotion', 'name',
+  'otag', 'oracletag', 'function',
+  'atag', 'arttag'
+]);
+
+const KNOWN_OTAGS = new Set([
+  'ramp', 'mana-rock', 'mana-dork', 'mana-doubler', 'mana-sink', 'land-ramp', 'ritual',
+  'draw', 'card-draw', 'cantrip', 'loot', 'looting', 'wheel', 'impulse-draw', 'scry',
+  'tutor', 'land-tutor', 'creature-tutor', 'artifact-tutor', 'enchantment-tutor', 'instant-or-sorcery-tutor',
+  'removal', 'spot-removal', 'creature-removal', 'artifact-removal', 'enchantment-removal', 'planeswalker-removal',
+  'board-wipe', 'mass-removal', 'graveyard-hate', 'graveyard-recursion', 'reanimation',
+  'token-generator', 'treasure-generator', 'food-generator', 'clue-generator', 'blood-generator',
+  'lifegain', 'soul-warden-ability', 'burn', 'fog', 'combat-trick', 'pump',
+  'blink', 'flicker', 'bounce', 'mass-bounce', 'copy', 'copy-permanent', 'copy-spell', 'clone',
+  'stax', 'hatebear', 'pillowfort', 'theft', 'mind-control', 'threaten',
+  'sacrifice-outlet', 'free-sacrifice-outlet', 'aristocrats', 'death-trigger', 'grave-pact-effect', 'blood-artist-effect',
+  'synergy-sacrifice', 'synergy-lifegain', 'synergy-discard', 'synergy-equipment', 'synergy-proliferate',
+  'extra-turn', 'extra-combat', 'polymorph', 'egg', 'activate-from-graveyard', 'cast-from-graveyard',
+  'untapper', 'tapper', 'gives-flash', 'gives-hexproof', 'gives-haste', 'gives-flying', 'gives-trample',
+  'gives-vigilance', 'gives-deathtouch', 'gives-lifelink', 'gives-first-strike', 'gives-double-strike',
+  'gives-menace', 'gives-reach', 'gives-protection', 'gives-indestructible',
+  'landfall', 'extra-land', 'enchantress', 'discard-outlet', 'mulch', 'lord', 'anthem',
+  'self-mill', 'mill', 'graveyard-order-matters'
+]);
+
+export function normalizeOrGroups(query: string): string {
+  const tokens: string[] = [];
+  let current = '';
+  let depth = 0;
+  let inQuote = false;
+
+  for (const char of query) {
+    if (char === '"') {
+      inQuote = !inQuote;
+    }
+    if (!inQuote && char === ' ') {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current) tokens.push(current);
+
+  const output: string[] = [];
+  let orGroup: string[] = [];
+  let inOrGroup = false;
+
+  const flushGroup = () => {
+    if (inOrGroup && orGroup.length > 0) {
+      output.push(`(${orGroup.join(' ')})`);
+    }
+    orGroup = [];
+    inOrGroup = false;
+  };
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    const openCount = (token.match(/\(/g) || []).length;
+    const closeCount = (token.match(/\)/g) || []).length;
+    const depthBefore = depth;
+    depth += openCount - closeCount;
+
+    if (depthBefore === 0 && token === 'OR') {
+      if (!inOrGroup) {
+        const previous = output.pop();
+        if (previous) {
+          orGroup.push(previous);
+        }
+        inOrGroup = true;
+      }
+      orGroup.push(token);
+      continue;
+    }
+
+    if (inOrGroup && depthBefore === 0) {
+      orGroup.push(token);
+      const nextToken = tokens[i + 1];
+      if (!nextToken || nextToken !== 'OR') {
+        flushGroup();
+      }
+      continue;
+    }
+
+    output.push(token);
+  }
+
+  if (inOrGroup) {
+    flushGroup();
+  }
+
+  return output.join(' ');
+}
+
+export function validateScryfallQuery(query: string): { valid: boolean; sanitized: string; issues: string[] } {
+  const issues: string[] = [];
+  let sanitized = query.replace(/[\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+
+  const normalizedOr = normalizeOrGroups(sanitized);
+  if (normalizedOr !== sanitized) {
+    sanitized = normalizedOr;
+    issues.push('Normalized OR groups with parentheses');
+  }
+
+  if (/\be:(\d{4})\b/i.test(sanitized)) {
+    sanitized = sanitized.replace(/\be:(\d{4})\b/gi, 'year=$1');
+    issues.push('Replaced invalid year set syntax with year=YYYY');
+  }
+
+  if (/\b(pow|power)\s*\+\s*(tou|toughness)\b/i.test(sanitized)) {
+    sanitized = sanitized.replace(/\b(pow|power)\s*\+\s*(tou|toughness)\s*[<>=]+?\s*\d+\b/gi, '').trim();
+    issues.push('Removed unsupported power+toughness math');
+  }
+
+  const keyPattern = /\b([a-zA-Z]+)[:=<>]/g;
+  const unknownKeys: string[] = [];
+  let keyMatch;
+  while ((keyMatch = keyPattern.exec(sanitized)) !== null) {
+    const key = keyMatch[1].toLowerCase();
+    if (!VALID_SEARCH_KEYS.has(key)) {
+      unknownKeys.push(key);
+    }
+  }
+  if (unknownKeys.length > 0) {
+    issues.push(`Unknown search key(s): ${unknownKeys.join(', ')}`);
+    for (const key of unknownKeys) {
+      sanitized = sanitized.replace(new RegExp(`\\b${key}[:=<>][^\\s]*`, 'gi'), '').trim();
+    }
+  }
+
+  const otagPattern = /\botag:([a-z0-9-]+)\b/gi;
+  const unknownTags: string[] = [];
+  let tagMatch;
+  while ((tagMatch = otagPattern.exec(sanitized)) !== null) {
+    const tag = tagMatch[1].toLowerCase();
+    if (!KNOWN_OTAGS.has(tag)) {
+      unknownTags.push(tag);
+    }
+  }
+  if (unknownTags.length > 0) {
+    issues.push(`Unknown oracle tag(s): ${unknownTags.join(', ')}`);
+    for (const tag of unknownTags) {
+      sanitized = sanitized.replace(new RegExp(`\\botag:${tag}\\b`, 'gi'), '').trim();
+    }
+  }
+
+  sanitized = sanitized.replace(/\s+/g, ' ').trim();
+
+  return { valid: issues.length === 0, sanitized, issues };
+}
+
+export function buildFilterQuery(filters?: FilterState | null): string {
+  if (!filters) return '';
+  const parts: string[] = [];
+
+  if (filters.colors.length > 0) {
+    const colorTokens = filters.colors.map(color => color === 'C' ? 'c=c' : `c:${color.toLowerCase()}`);
+    parts.push(`(${colorTokens.join(' OR ')})`);
+  }
+
+  if (filters.types.length > 0) {
+    const typeTokens = filters.types.map(type => `t:${type.toLowerCase()}`);
+    parts.push(`(${typeTokens.join(' OR ')})`);
+  }
+
+  const [minCmc, maxCmc] = filters.cmcRange;
+  if (minCmc > 0) {
+    parts.push(`mv>=${minCmc}`);
+  }
+  if (maxCmc < 16) {
+    parts.push(`mv<=${maxCmc}`);
+  }
+
+  return parts.join(' ').trim();
+}

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -1,0 +1,6 @@
+export interface FilterState {
+  colors: string[];
+  types: string[];
+  cmcRange: [number, number];
+  sortBy: string;
+}

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,0 +1,16 @@
+export interface SearchIntent {
+  colors: {
+    values: string[];
+    isIdentity: boolean;
+    isExact: boolean;
+    isOr: boolean;
+  } | null;
+  types: string[];
+  cmc: { op: string; value: number } | null;
+  power: { op: string; value: number } | null;
+  toughness: { op: string; value: number } | null;
+  tags: string[];
+  oraclePatterns: string[];
+  warnings: string[];
+  deterministicQuery?: string;
+}


### PR DESCRIPTION
### Motivation
- Reduce invalid or ambiguous Scryfall queries by extracting deterministic constraints before calling the LLM and by validating/sanitizing generated queries. 
- Prefer `otag:` (oracle tags) and provide tag-first mappings so effect-based searches are more accurate and predictable. 
- Surface the deterministic compilation to users and allow safer, filter-aware reruns of compiled Scryfall queries. 
- Improve UX for reusing cached translations and for copying card details from results.

### Description
- Add deterministic intent parsing and normalization in the edge function (`supabase/functions/semantic-search/index.ts`) including `normalizeOrGroups`, `parseIntent`, `applyTagFirstMappings`, `buildDeterministicIntent`, known `otag` validation, and deterministic query merging into the AI prompt and cache flow. 
- Harden query sanitization in `validateQuery` (OR-group wrapping, year/set fixes, removal of unsupported pow+tou math, unknown key/otag stripping) and expose a client-side helper `src/lib/scryfallQuery.ts` with `validateScryfallQuery`, `normalizeOrGroups`, and `buildFilterQuery`. 
- Wire deterministic output and validation into responses and caching (added `useCache` flag to request payloads) and include `intent`, `deterministicQuery`, and `validationIssues` in API responses. 
- UI changes: add `ExplainCompilationPanel` (`src/components/ExplainCompilationPanel.tsx`), show editable compiled query with validation in `EditableQueryBar`, add a `Use last` reuse toggle and cache-awareness to `UnifiedSearchBar`, pass filters through to the function, add copy-name/link actions to `CardItem`, and introduce `FilterState`/`SearchIntent` types and `buildFilterQuery` usage in `src/pages/Index.tsx`.

### Testing
- Started the dev server with `npm run dev` and the app compiled and served successfully (Vite reported being ready). 
- Executed a Playwright script that loaded the UI, filled the search box with `cheap green ramp`, clicked search, and produced a screenshot at `artifacts/compiled-query-panel.png`, confirming the compiled-query panel and interactions rendered (script completed). 
- No automated unit/test-suite runs were added for parsing logic in this change-set. 
- Manual runtime checks performed during development did not surface runtime errors for the updated flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961e6aa8a848330aa0f0bb924fe6ad7)