### PR TITLE
Add Mermaid architecture flowchart to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,27 @@ npm run dev
 
 For Edge Function environment variables, see [`docs/configuration.md`](docs/configuration.md).
 
+## How it works
+- You enter a natural-language query in the UI (text or voice).
+- The frontend sends the request to a Supabase Edge Function for interpretation.
+- The Edge Function deterministically translates the prompt to Scryfall syntax and uses AI only as a fallback.
+- The Edge Function queries the Scryfall API with the generated search string.
+- Results are returned to the UI, cached client-side, and rendered as cards with details and printings.
+
+```mermaid
+flowchart LR
+  UI["UI (text/voice)"] --> Edge["Supabase Edge Function"]
+  Edge --> Translate["Deterministic translation"]
+  Translate -->|fallback| AI["AI interpretation"]
+  Translate --> Scryfall["Scryfall API"]
+  AI --> Scryfall
+  Scryfall --> Results["Results + metadata"]
+  Results --> UI
+  UI --> Cache["Client cache"]
+```
+
+For a deeper architecture overview, see [`docs/architecture.md`](docs/architecture.md).
+
 ## Usage examples
 Try these sample queries:
 1. "artifact that produced 2 mana and costs four or less mana"


### PR DESCRIPTION
### Motivation
- Make the request flow explicit and easier to understand by visualizing the components and data flow. 
- Highlight the deterministic translation behavior and the AI fallback used by the Edge Function. 
- Provide a quick architecture overview for newcomers and contributors without requiring them to open `docs/architecture.md`. 

### Description
- Update `README.md` `How it works` section to include a Mermaid flowchart illustrating the request flow. 
- The diagram shows `UI (text/voice)`, `Supabase Edge Function`, `Deterministic translation`, `AI interpretation` (fallback), `Scryfall API`, `Results + metadata`, and `Client cache` and their interactions. 
- This is a documentation-only change and does not modify runtime code or application behavior. 

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696542a1d1f083308e590802b4b8ed99)