### PR TITLE
Fix lint warnings: hook deps, type-only imports, and fast-refresh exports

### DIFF
--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -3,8 +3,9 @@
  * Memoized to prevent unnecessary re-renders in large lists.
  */
 
-import { memo, KeyboardEvent, MouseEvent } from "react";
-import { ScryfallCard } from "@/types/card";
+import { memo } from "react";
+import type { KeyboardEvent, MouseEvent } from "react";
+import type { ScryfallCard } from "@/types/card";
 import { getCardImage } from "@/lib/scryfall";
 import { cn } from "@/lib/utils";
 import { Copy, Link2 } from "lucide-react";

--- a/src/components/CardModal.tsx
+++ b/src/components/CardModal.tsx
@@ -7,9 +7,11 @@
  */
 
 import { useState, useEffect } from "react";
-import { ScryfallCard } from "@/types/card";
-import { getCardImage, isDoubleFacedCard, getCardFaceDetails, getCardRulings, CardRuling } from "@/lib/scryfall";
-import { getCardPrintings, getTCGPlayerUrl, getCardmarketUrl, CardPrinting } from "@/lib/card-printings";
+import type { ScryfallCard } from "@/types/card";
+import { getCardImage, isDoubleFacedCard, getCardFaceDetails, getCardRulings } from "@/lib/scryfall";
+import type { CardRuling } from "@/lib/scryfall";
+import { getCardPrintings, getTCGPlayerUrl, getCardmarketUrl } from "@/lib/card-printings";
+import type { CardPrinting } from "@/lib/card-printings";
 
 import { ManaCost, OracleText } from "./ManaSymbol";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";

--- a/src/components/EditableQueryBar.tsx
+++ b/src/components/EditableQueryBar.tsx
@@ -7,13 +7,11 @@ import { useState, useEffect, useCallback, memo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { toast } from 'sonner';
-import { Play, Copy, Check, ExternalLink, Edit2, AlertTriangle, X, RotateCcw } from 'lucide-react';
+import { Play, Copy, Check, ExternalLink, AlertTriangle, X, RotateCcw } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { FilterState } from '@/types/filters';
 
 interface EditableQueryBarProps {
   scryfallQuery: string;
-  originalQuery: string;
   confidence?: number;
   isLoading?: boolean;
   validationError?: string | null;
@@ -21,12 +19,10 @@ interface EditableQueryBarProps {
   onRegenerate?: () => void;
   onReportIssue?: () => void;
   requestId?: string;
-  filters?: FilterState | null;
 }
 
 export const EditableQueryBar = memo(function EditableQueryBar({
   scryfallQuery,
-  originalQuery,
   confidence,
   isLoading,
   validationError,
@@ -34,7 +30,6 @@ export const EditableQueryBar = memo(function EditableQueryBar({
   onRegenerate,
   onReportIssue,
   requestId,
-  filters,
 }: EditableQueryBarProps) {
   const [editedQuery, setEditedQuery] = useState(scryfallQuery);
   const [isEditing, setIsEditing] = useState(false);

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
-import { Component, ReactNode } from "react";
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
 import { AlertTriangle, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { logger } from "@/lib/logger";
@@ -23,7 +24,7 @@ export class ErrorBoundary extends Component<Props, State> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     logger.error("ErrorBoundary caught an error:", error, errorInfo);
   }
 

--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -155,7 +155,7 @@ export function SearchFilters({ cards, onFilteredCards, totalCards }: SearchFilt
   // Notify parent of filtered results - use useEffect instead of useMemo for side effects
   useEffect(() => {
     onFilteredCards(filteredCards, hasActiveFilters, filters);
-  }, [filteredCards, hasActiveFilters, onFilteredCards]);
+  }, [filteredCards, hasActiveFilters, onFilteredCards, filters]);
 
   const toggleColor = useCallback((colorId: string) => {
     setFilters(prev => ({

--- a/src/components/UnifiedSearchBar.tsx
+++ b/src/components/UnifiedSearchBar.tsx
@@ -200,14 +200,7 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
     return () => clearInterval(interval);
   }, [rateLimitedUntil]);
 
-  useImperativeHandle(ref, () => ({
-    triggerSearch: (searchQuery: string, options?: { bypassCache?: boolean; cacheSalt?: string }) => {
-      setQuery(searchQuery);
-      handleSearch(searchQuery, options);
-    }
-  }), []);
-
-  const handleSearch = async (searchQuery?: string, options?: { bypassCache?: boolean; cacheSalt?: string }) => {
+  const handleSearch = useCallback(async (searchQuery?: string, options?: { bypassCache?: boolean; cacheSalt?: string }) => {
     const queryToSearch = (searchQuery || query).trim();
     
     // Prevent empty, duplicate, or rate-limited searches
@@ -347,7 +340,24 @@ export const UnifiedSearchBar = forwardRef<UnifiedSearchBarHandle, UnifiedSearch
       setIsSearching(false);
       abortControllerRef.current = null;
     }
-  };
+  }, [
+    addToHistory,
+    filters,
+    getContext,
+    onSearch,
+    query,
+    rateLimitCountdown,
+    rateLimitedUntil,
+    saveContext,
+    useLast,
+  ]);
+
+  useImperativeHandle(ref, () => ({
+    triggerSearch: (searchQuery: string, options?: { bypassCache?: boolean; cacheSalt?: string }) => {
+      setQuery(searchQuery);
+      handleSearch(searchQuery, options);
+    }
+  }), [handleSearch]);
 
   const showExamples = !query;
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { VariantProps, cva } from "class-variance-authority";

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useTheme } from "next-themes";
 import { Toaster as Sonner, toast } from "sonner";
 

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -69,7 +69,7 @@ const Index = () => {
       setHasActiveFilters(false);
       setCurrentRequestId(null);
     }
-  }, [urlQuery]); // Re-run when URL query changes
+  }, [urlQuery, hasSearched, searchQuery]); // Re-run when URL query changes
 
   const {
     data,
@@ -363,14 +363,12 @@ const Index = () => {
               <div className="animate-reveal">
                 <EditableQueryBar
                   scryfallQuery={(lastSearchResult?.scryfallQuery || searchQuery).trim()}
-                  originalQuery={originalQuery}
                   confidence={lastSearchResult?.explanation?.confidence}
                   isLoading={isSearching}
                   onRerun={handleRerunEditedQuery}
                   onRegenerate={handleRegenerateTranslation}
                   onReportIssue={() => setReportDialogOpen(true)}
                   requestId={currentRequestId || undefined}
-                  filters={activeFilters}
                   validationError={lastSearchResult?.validationIssues?.length ? lastSearchResult.validationIssues.join(' • ') : null}
                 />
               </div>


### PR DESCRIPTION
### Motivation

- Silence React Hook lint warnings by ensuring effects and imperative handles include the correct dependencies to avoid stale closures and unexpected behavior.
- Remove unused props and convert runtime-only imports to type-only imports to satisfy TypeScript/ESLint rules about unused values.
- Prevent fast-refresh warnings by marking shared UI files as non-component-only exports so hot reload behaves correctly.

### Description

- Add missing dependencies to effects: updated the URL sync effect in `src/pages/Index.tsx` to include `hasSearched` and `searchQuery`, and added `filters` to the dependency list in `src/components/SearchFilters.tsx`.
- Memoized the search handler in `src/components/UnifiedSearchBar.tsx` with `useCallback` and wired `useImperativeHandle` to depend on the memoized handler to fix missing-deps warnings.
- Cleaned up unused props and imports: removed `originalQuery`/`filters` usage from `EditableQueryBar` and converted several imports to `type` imports (e.g. in `CardModal.tsx`, `CardItem.tsx`, `ErrorBoundary.tsx`).
- Suppressed react-refresh fast-refresh-only exports warnings by adding `/* eslint-disable react-refresh/only-export-components */` to shared UI modules under `src/components/ui/*` (e.g. `button.tsx`, `badge.tsx`, `form.tsx`, `toggle.tsx`, `navigation-menu.tsx`, `sidebar.tsx`, `sonner.tsx`).

### Testing

- No automated tests were run for this change.
- A commit was created containing the lint fixes and refactors and is ready for CI verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654395c49483309f307f898b67f1cd)