### PR TITLE
Mark LabelPrimitive import as type-only

### DIFF
--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as LabelPrimitive from "@radix-ui/react-label";
+import type * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
 import { Controller, FormProvider, useFormContext } from "react-hook-form";
 import type { ControllerProps, FieldPath, FieldValues } from "react-hook-form";


### PR DESCRIPTION
### Motivation
- ESLint reported that the `LabelPrimitive` import is only used as a type and flagged it under `@typescript-eslint/consistent-type-imports`.
- Convert the import to a type-only import to satisfy the lint rule and avoid runtime changes.

### Description
- Changed the import from `import * as LabelPrimitive from "@radix-ui/react-label";` to `import type * as LabelPrimitive from "@radix-ui/react-label";` in `src/components/ui/form.tsx`.
- No other codepaths or runtime behavior were modified.

### Testing
- `npm run lint` before the change failed with the type-only import error (ESLint reported the `consistent-type-imports` issue).
- `npm run lint` after the change failed due to a missing dependency error for `eslint-config-prettier`, not because of the changed import.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654a0992ac83308ac62533468d60ab)