### PR TITLE
Treat "commander deck" phrasing as Commander format in deterministic parser

### DIFF
--- a/src/lib/search/deterministic.test.ts
+++ b/src/lib/search/deterministic.test.ts
@@ -91,7 +91,8 @@ describe('Deterministic MTG query translation', () => {
   it('T12: fits into a BR commander deck', () => {
     const query = getQuery('fits into a BR commander deck');
     expect(query).toContain('ci<=br');
-    expect(query).toContain('is:commander');
+    expect(query).toContain('f:commander');
+    expect(query).not.toContain('is:commander');
   });
 
   it('T13: rakdos creature uses color (not identity)', () => {

--- a/supabase/functions/semantic-search/deterministic.ts
+++ b/supabase/functions/semantic-search/deterministic.ts
@@ -325,6 +325,12 @@ function parseCompanions(query: string, ir: SearchIR): string {
 function parseSpecialPatterns(query: string, ir: SearchIR): string {
   let remaining = query;
 
+  const commanderFormatPattern = /\bcommander(?:-|\s)?(deck|format|legal)\b|\blegal in commander\b/gi;
+  if (commanderFormatPattern.test(remaining)) {
+    ir.specials.push('f:commander');
+    remaining = remaining.replace(commanderFormatPattern, '').trim();
+  }
+
   if (/\bcommander\b|\bis:commander\b|\bas commander\b|\bcommanders\b/i.test(remaining)) {
     ir.specials.push('is:commander');
     remaining = remaining.replace(/\b(?:as )?commander\b/gi, '').trim();


### PR DESCRIPTION
### Motivation
- Fix ambiguity between references to the Commander format (e.g., “commander deck”, “commander legal”) and references to commander-only cards.
- Ensure searches like `fits into a BR commander deck` apply a format filter instead of marking cards as `is:commander` to better reflect intended Scryfall queries.
- Improve deterministic query generation so downstream validation and AI translation receive correct constraints.

### Description
- Added a `commanderFormatPattern` regex in `supabase/functions/semantic-search/deterministic.ts` that emits `f:commander` and strips matched text from the remaining query.
- Kept the existing `is:commander` detection for cases where users mean commander card identity or explicitly mention `commander` as a card role.
- Updated the deterministic unit test `T12` in `src/lib/search/deterministic.test.ts` to expect `f:commander` and to assert that `is:commander` is not present.
- Modified files: `supabase/functions/semantic-search/deterministic.ts` and `src/lib/search/deterministic.test.ts`.

### Testing
- Updated unit test expectations in `src/lib/search/deterministic.test.ts` to match the new behavior (no test suite execution in this change set).
- No automated test commands (e.g., `vitest` or CI) were executed as part of this change, so no pass/fail results are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654a71fc788330bedd79e118179039)