### PR TITLE
Allow Tagger `art:` key and avoid normalizing OR inside regexes

### DIFF
--- a/src/lib/scryfallQuery.test.ts
+++ b/src/lib/scryfallQuery.test.ts
@@ -21,6 +21,11 @@ describe('normalizeOrGroups', () => {
     const query = 'o:"draw OR discard" c:red OR c:blue';
     expect(normalizeOrGroups(query)).toBe('o:"draw OR discard" (c:red OR c:blue)');
   });
+
+  it('ignores OR inside regex patterns', () => {
+    const query = 'o:/draw OR discard/ c:red OR c:blue';
+    expect(normalizeOrGroups(query)).toBe('o:/draw OR discard/ (c:red OR c:blue)');
+  });
 });
 
 describe('validateScryfallQuery', () => {

--- a/src/lib/scryfallQuery.ts
+++ b/src/lib/scryfallQuery.ts
@@ -14,7 +14,7 @@ export const VALID_SEARCH_KEYS = new Set([
   'st', 'cube', 'order', 'direction', 'unique', 'prefer', 'include',
   'produces', 'devotion', 'name',
   'otag', 'oracletag', 'function',
-  'atag', 'arttag'
+  'art', 'atag', 'arttag'
 ]);
 
 export const KNOWN_OTAGS = new Set([
@@ -42,12 +42,16 @@ export function normalizeOrGroups(query: string): string {
   let current = '';
   let depth = 0;
   let inQuote = false;
+  let inRegex = false;
 
   for (const char of query) {
     if (char === '"') {
       inQuote = !inQuote;
     }
-    if (!inQuote && char === ' ') {
+    if (!inQuote && char === '/' && current.at(-1) !== '\\') {
+      inRegex = !inRegex;
+    }
+    if (!inQuote && !inRegex && char === ' ') {
       if (current) {
         tokens.push(current);
         current = '';

--- a/src/lib/scryfallSyntax.test.ts
+++ b/src/lib/scryfallSyntax.test.ts
@@ -35,6 +35,7 @@ describe('Scryfall syntax reference coverage', () => {
       'name:/^goblin/',
       't:/dragon/',
       'o:/destroy target (creature|artifact)/',
+      'o:/draw OR discard/',
     ];
 
     for (const query of regexQueries) {


### PR DESCRIPTION
### Motivation
- Support Scryfall Tagger artwork searches (e.g. `art:`) in the query key whitelist. 
- Prevent the OR-group normalizer from splitting regex literals that contain `OR` (preserve `/<... OR ...>/`).
- Improve coverage for regex handling and OR normalization in unit tests.

### Description
- Add `'art'` to `VALID_SEARCH_KEYS` so `art:` queries are treated as valid keys in `src/lib/scryfallQuery.ts`.
- Track regex literals in `normalizeOrGroups` by toggling an `inRegex` flag on unescaped `/` and avoid splitting on spaces while inside regexes. 
- Add a test that ensures `normalizeOrGroups` ignores `OR` inside regex patterns in `src/lib/scryfallQuery.test.ts`. 
- Extend `src/lib/scryfallSyntax.test.ts` to include a regex containing `OR` so `validateScryfallQuery` preserves such regex queries.

### Testing
- Updated unit tests in `src/lib/scryfallQuery.test.ts` and `src/lib/scryfallSyntax.test.ts` were committed but no test runner output is available locally. 
- Attempted to run the test suite with `npm test` (which runs `vitest`), but the run failed because `vitest` was not found in the execution environment (exit due to missing dev dependency).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654bb26b708330b6030094dab566f0)