### PR TITLE
Reset filters on new searches and sync CMC range with results

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -48,6 +48,7 @@ const Index = () => {
   const [reportDialogOpen, setReportDialogOpen] = useState(false);
   const [activeFilters, setActiveFilters] = useState<FilterState | null>(null);
   const [lastIntent, setLastIntent] = useState<SearchIntent | null>(null);
+  const [filtersResetKey, setFiltersResetKey] = useState(0);
   
   const searchBarRef = useRef<UnifiedSearchBarHandle>(null);
   const loadMoreRef = useRef<HTMLDivElement>(null);
@@ -115,9 +116,10 @@ const Index = () => {
     // Clear prior state before setting new values
     setFilteredCards([]);
     setHasActiveFilters(false);
+    setActiveFilters(null);
+    setFiltersResetKey(prev => prev + 1);
     
-    const filterQuery = buildFilterQuery(activeFilters);
-    const executedQuery = [query, filterQuery].filter(Boolean).join(' ').trim();
+    const executedQuery = query.trim();
 
     setSearchQuery(executedQuery);
     setOriginalQuery(naturalQuery || query);
@@ -138,7 +140,7 @@ const Index = () => {
     }
     
     // Invalidate previous query cache to force fresh fetch
-    queryClient.invalidateQueries({ queryKey: ["cards", searchQuery] });
+    queryClient.invalidateQueries({ queryKey: ["cards", executedQuery] });
     
     // Update URL with search query
     if (query) {
@@ -155,7 +157,7 @@ const Index = () => {
         results_count: 0,
       });
     }
-  }, [trackSearch, setSearchParams, queryClient, searchQuery, activeFilters]);
+  }, [trackSearch, setSearchParams, queryClient]);
 
   // Handle re-running with an edited Scryfall query (bypasses AI translation)
   const handleRerunEditedQuery = useCallback((editedQuery: string) => {
@@ -200,7 +202,7 @@ const Index = () => {
     });
     
     // Invalidate cache and force new fetch
-    queryClient.invalidateQueries({ queryKey: ["cards"] });
+    queryClient.invalidateQueries({ queryKey: ["cards", validation.sanitized] });
     
     // Update URL
     setSearchParams({ q: validation.sanitized }, { replace: true });
@@ -399,6 +401,7 @@ const Index = () => {
                 cards={cards} 
                 onFilteredCards={handleFilteredCards}
                 totalCards={totalCards}
+                resetKey={filtersResetKey}
               />
             )}
 


### PR DESCRIPTION
### Motivation
- Ensure filters do not persist across new searches so results are accurate and UI state is consistent.  
- Avoid invalidating stale query caches by using the actual executed Scryfall query for cache keys.  
- Align the filters' default mana value range with the current result set so the slider and counts are meaningful.  
- Provide a mechanism to programmatically reset the filter UI when search results change.

### Description
- Added a `filtersResetKey` state and pass it to `SearchFilters` via the `resetKey` prop to drive UI resets from the search flow.  
- Updated `handleSearch` to clear `activeFilters`, increment `filtersResetKey`, trim the executed query, and call `queryClient.invalidateQueries` with the executed query key.  
- Adjusted `handleRerunEditedQuery` to invalidate the cache with `validation.sanitized` and ensure edited queries are validated before running.  
- Reworked `SearchFilters` to compute `defaultMaxCmc`, expose `defaultFilters`, reset filters on `resetKey` changes, preserve non-default user ranges when the default max changes, and use `defaultMaxCmc` for slider/display/clear logic.

### Testing
- Attempted to run dependency install/automated checks via `npm install`, but it failed with a 403 error fetching `eslint-config-prettier`, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654be78b64833097210fd3e3e3307d)