### PR TITLE
Add Vitest v8 coverage dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@types/react": "^18.3.23",
     "@types/react-dom": "^18.3.7",
     "@vitejs/plugin-react-swc": "^3.11.0",
+    "@vitest/coverage-v8": "^2.1.9",
     "autoprefixer": "^10.4.21",
     "eslint": "^9.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig(({ mode }) => ({
     environment: "node",
     include: ["src/**/*.test.ts"],
     coverage: {
+      provider: "v8",
       reporter: ["text", "lcov"],
       lines: 60,
       functions: 60,


### PR DESCRIPTION
### Motivation
- Enable Vitest to use the V8 coverage provider for more accurate JS coverage reporting.
- Ensure the project has the corresponding coverage provider package available alongside `vitest`.
- Make the coverage provider explicit in the test configuration to avoid provider mismatches.

### Description
- Added `@vitest/coverage-v8` to `devDependencies` in `package.json`.
- Set `provider: "v8"` under `test.coverage` in `vite.config.ts` to match the installed provider.
- Kept existing coverage reporters (`text`, `lcov`) and thresholds unchanged.

### Testing
- Ran `npm install`, which failed with a `403 Forbidden` when fetching `@vitest/coverage-v8` in this environment.
- No other automated tests were run as part of this change due to the install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654e347f20833087a6d3c292b223fb)