### PR TITLE
Handle TCGPlayer env fallback and avoid reusing fetch body in Scryfall client

### DIFF
--- a/src/lib/card-printings.test.ts
+++ b/src/lib/card-printings.test.ts
@@ -160,11 +160,8 @@ describe("purchase URL helpers", () => {
   });
 
   it("builds a TCGPlayer URL with affiliate wrapping when configured", async () => {
-    const originalEnv = import.meta.env;
-    Object.defineProperty(import.meta, "env", {
-      value: { ...originalEnv, NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE: "https://aff.example/?u=" },
-      configurable: true,
-    });
+    const originalEnv = process.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE;
+    process.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE = "https://aff.example/?u=";
 
     const { getTCGPlayerUrl } = await import("@/lib/card-printings");
     const url = getTCGPlayerUrl(
@@ -176,7 +173,11 @@ describe("purchase URL helpers", () => {
 
     expect(url).toBe("https://aff.example/?u=https%3A%2F%2Ftcgplayer.com%2Fcard%2F1");
 
-    Object.defineProperty(import.meta, "env", { value: originalEnv, configurable: true });
+    if (originalEnv === undefined) {
+      delete process.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE;
+    } else {
+      process.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE = originalEnv;
+    }
   });
 
   it("falls back to search URLs when purchase URIs are missing", async () => {

--- a/src/lib/card-printings.ts
+++ b/src/lib/card-printings.ts
@@ -173,7 +173,11 @@ export async function getCardPrintings(cardName: string): Promise<CardPrinting[]
  * @returns TCGPlayer URL for purchasing the card (with affiliate tracking if configured)
  */
 export function getTCGPlayerUrl(card: ScryfallCard): string {
-  const affiliateBase = import.meta.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE;
+  const affiliateBase =
+    import.meta.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE ??
+    (typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE
+      : undefined);
   const purchaseUris = card.purchase_uris;
   
   // Get the base TCGPlayer URL

--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -136,7 +136,7 @@ export async function searchCards(query: string, page: number = 1): Promise<Sear
     throw new Error(`Search failed: ${response.statusText}`);
   }
   
-  return response.json();
+  return response.clone().json();
 }
 
 /**
@@ -154,7 +154,7 @@ export async function autocomplete(query: string): Promise<string[]> {
   
   if (!response.ok) return [];
   
-  const data: AutocompleteResult = await response.json();
+  const data: AutocompleteResult = await response.clone().json();
   return data.data;
 }
 
@@ -169,7 +169,7 @@ export async function getRandomCard(): Promise<ScryfallCard> {
     throw new Error(`Failed to get random card: ${response.statusText}`);
   }
   
-  return response.json();
+  return response.clone().json();
 }
 
 /**
@@ -188,7 +188,7 @@ export async function getCardByName(name: string): Promise<ScryfallCard> {
     throw new Error(`Card not found: ${name}`);
   }
   
-  return response.json();
+  return response.clone().json();
 }
 
 /**
@@ -318,7 +318,7 @@ export async function getCardRulings(cardId: string): Promise<CardRuling[]> {
       return [];
     }
     
-    const data = await response.json();
+    const data = await response.clone().json();
     const rulings: CardRuling[] = data.data || [];
     
     rulingsCache.set(cardId, { data: rulings, timestamp: Date.now() });


### PR DESCRIPTION
### Motivation

- Tests were failing because the TCGPlayer affiliate value was only read from `import.meta.env` in tests that set `process.env` instead. 
- Multiple tests and the test runner reported `TypeError: Body is unusable` when the same `Response` body was consumed more than once under queued/parallel fetches. 
- The changes aim to make environment lookup more robust in test environments and prevent repeated consumption of `Response` bodies. 
- Keep changes small and focused to address the two concrete failure modes seen in test output.

### Description

- Added a fallback to `process.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE` in `getTCGPlayerUrl` so the affiliate base can be supplied from `process.env` when `import.meta.env` is unavailable (edited `src/lib/card-printings.ts`).
- Updated the test to set `process.env.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE` instead of manipulating `import.meta.env` (edited `src/lib/card-printings.test.ts`).
- Prevented reusing the same fetch body by parsing cloned responses via `response.clone().json()` in `searchCards`, `autocomplete`, `getRandomCard`, `getCardByName`, and `getCardRulings` (edited `src/lib/scryfall.ts`).
- Minor test housekeeping to restore `process.env` after the affiliate URL test completes.

### Testing

- Attempted to run the test suite with `npm run test -- --coverage`, but the environment reported `vitest: not found`, so the full test run could not be executed here.
- The change specifically targets the previously observed failures: affiliate URL wrapping and `Body is unusable` errors, which should be resolved by the env fallback and cloning responses respectively when run in a full test environment.
- No other automated test runs were completed in this environment due to the missing test runner.
- Please run `npm run test -- --coverage` in CI or a local environment with `vitest` installed to verify all tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d27d5a748330bb95df8289e478db)