### PR TITLE
Log Scryfall rulings fetch failures

### DIFF
--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -315,6 +315,7 @@ export async function getCardRulings(cardId: string): Promise<CardRuling[]> {
     );
     
     if (!response.ok) {
+      logger.error("Failed to fetch rulings:", response.status, response.statusText);
       return [];
     }
     


### PR DESCRIPTION
### Motivation
- Non-OK responses from the Scryfall rulings endpoint were returned silently without logging, making failures harder to diagnose.
- The ruling-fetch tests expect an error log when failures occur, so logging is needed to satisfy observability and test expectations.
- Keep the change small and focused to improve debugability for Scryfall calls.

### Description
- Added an error log call for non-OK rulings responses in `getCardRulings` using `logger.error` to surface status and statusText.
- No functional change to the returned values or caching behavior in `getCardRulings`.
- Change made in `src/lib/scryfall.ts`.

### Testing
- Running the full test suite with `npm run test -- --coverage` (pre-change) produced 55 passed and 1 failed test (`scryfall client > fetches rulings with caching and error handling`).
- After the change, a targeted test run `npm run test -- src/lib/scryfall.test.ts` could not be executed in the environment because `vitest` was not found, so the focused tests were not re-run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d503500083308aed42324abb072f)