### PR TITLE
Add tests for Cardmarket URL and non-Node env TCGPlayer handling

### DIFF
--- a/src/lib/card-printings.test.ts
+++ b/src/lib/card-printings.test.ts
@@ -190,4 +190,33 @@ describe("purchase URL helpers", () => {
       "https://www.cardmarket.com/en/Magic/Products/Search",
     );
   });
+
+  it("uses the cardmarket purchase URI when provided", async () => {
+    const { getCardmarketUrl } = await import("@/lib/card-printings");
+
+    const card = buildCard({
+      name: "Tundra",
+      purchase_uris: { cardmarket: "https://cardmarket.example/tundra" },
+    });
+
+    expect(getCardmarketUrl(card)).toBe("https://cardmarket.example/tundra");
+  });
+
+  it("skips process env fallback when process is unavailable", async () => {
+    const originalProcess = globalThis.process;
+    // @ts-expect-error - simulate a non-Node environment
+    globalThis.process = undefined;
+
+    const { getTCGPlayerUrl } = await import("@/lib/card-printings");
+    const url = getTCGPlayerUrl(
+      buildCard({
+        name: "Mana Vault",
+        purchase_uris: { tcgplayer: "https://tcgplayer.com/card/2" },
+      }),
+    );
+
+    expect(url).toBe("https://tcgplayer.com/card/2");
+
+    globalThis.process = originalProcess;
+  });
 });


### PR DESCRIPTION
### Motivation
- Improve coverage for purchase URL helpers in `src/lib/card-printings.ts` by exercising fallback and explicit-purchase-uri code paths.
- Ensure `getCardmarketUrl` returns embedded Cardmarket URIs when present.
- Verify `getTCGPlayerUrl` does not attempt to read `process.env` when `process` is not available (simulating a non-Node environment).

### Description
- Added two unit tests to `src/lib/card-printings.test.ts` to cover the Cardmarket purchase URI and non-Node environment behavior.
- Tests exercise `getCardmarketUrl` with an explicit `cardmarket` URI and `getTCGPlayerUrl` with `globalThis.process` temporarily set to `undefined`.
- Restores `globalThis.process` after the simulation to avoid global side effects.
- Kept tests focused and isolated to avoid impacting existing suites.

### Testing
- No automated test run was performed as part of this change.
- The new tests are located in `src/lib/card-printings.test.ts` and will run under the existing Vitest test suite when executed.
- Existing CI/test configuration was not modified.
- Local commit was created with the updated test file."}

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d74397b883309413cdf4b4f2f678)