### PR TITLE
Guard env access in TCGPlayer URL helper

### DIFF
--- a/src/lib/card-printings.ts
+++ b/src/lib/card-printings.ts
@@ -173,7 +173,13 @@ export async function getCardPrintings(cardName: string): Promise<CardPrinting[]
  * @returns TCGPlayer URL for purchasing the card (with affiliate tracking if configured)
  */
 export function getTCGPlayerUrl(card: ScryfallCard): string {
-  const metaEnv = typeof import.meta !== "undefined" ? import.meta.env : undefined;
+  const metaEnv = (() => {
+    try {
+      return import.meta.env;
+    } catch {
+      return undefined;
+    }
+  })();
   const processEnv = typeof process !== "undefined" ? process.env : undefined;
   const affiliateBase =
     metaEnv?.NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE ??


### PR DESCRIPTION
### Motivation
- Prevent runtime `TypeError` when `import.meta` or `process` are undefined while constructing TCGPlayer affiliate URLs (seen in test/worker environments). 

### Description
- Replace direct `import.meta.env`/`process.env` access with guarded `metaEnv` and `processEnv` variables and use optional chaining to read `NEXT_PUBLIC_TCGPLAYER_IMPACT_BASE` in `src/lib/card-printings.ts`.

### Testing
- `npm run test -- --coverage` (pre-change CI run) revealed a failing test and `TypeError: Cannot read properties of undefined (reading 'env')`.
- After applying the guard, `npm run test -- src/lib/card-printings.test.ts` could not be executed in this environment because `vitest` was not found, so tests were not re-run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966fcaf54788330b5df6de8cf044a41)