### PR TITLE
Omit cookies for Scryfall API fetches

### DIFF
--- a/src/lib/card-printings.ts
+++ b/src/lib/card-printings.ts
@@ -68,7 +68,10 @@ async function fetchWithTimeout(
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    return await fetch(url, { signal: controller.signal });
+    return await fetch(url, {
+      signal: controller.signal,
+      credentials: 'omit',
+    });
   } finally {
     clearTimeout(timeoutId);
   }

--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -89,7 +89,10 @@ async function fetchWithTimeout(
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
-    return await fetch(url, { signal: controller.signal });
+    return await fetch(url, {
+      signal: controller.signal,
+      credentials: 'omit',
+    });
   } finally {
     clearTimeout(timeoutId);
   }


### PR DESCRIPTION
### Motivation
- Prevent browser third-party cookie warnings (e.g. `"__cf_bm"` rejected for invalid domain) by ensuring credentials are not sent to external Scryfall endpoints.

### Description
- Add `credentials: 'omit'` to the `fetchWithTimeout` implementation used by `src/lib/scryfall.ts` and `src/lib/card-printings.ts` so all Scryfall-related `fetch` calls do not include cookies or other credentials.

### Testing
- Ran `prettier --write` and `eslint --max-warnings=0` as part of pre-commit tasks and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69771181b2bc8330ae0ca582ea4a1f7a)