### PR TITLE
Improve /decks deck-open UX with batched metadata hydration + e2e/a11y coverage

### DIFF
--- a/src/lib/scryfall/client.ts
+++ b/src/lib/scryfall/client.ts
@@ -146,11 +146,20 @@ async function fetchWithTimeout(
   url: string,
   timeoutMs: number,
 ): Promise<Response> {
+  return fetchWithTimeoutWithInit(url, timeoutMs);
+}
+
+async function fetchWithTimeoutWithInit(
+  url: string,
+  timeoutMs: number,
+  init?: RequestInit,
+): Promise<Response> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
   try {
     return await fetch(url, {
+      ...init,
       signal: controller.signal,
       credentials: 'omit',
     });
@@ -161,6 +170,7 @@ async function fetchWithTimeout(
 
 async function fetchWithRetry(
   url: string,
+  init?: RequestInit,
   retries = MAX_RETRIES,
 ): Promise<Response> {
   let attempt = 0;
@@ -168,7 +178,7 @@ async function fetchWithRetry(
 
   while (attempt <= retries) {
     try {
-      const response = await fetchWithTimeout(url, FETCH_TIMEOUT_MS);
+      const response = await fetchWithTimeoutWithInit(url, FETCH_TIMEOUT_MS, init);
       if (
         !response.ok &&
         (response.status === 429 || response.status >= 500) &&
@@ -232,6 +242,49 @@ export async function searchCards(
   const result: SearchResult = await response.json();
   setSearchCache(cacheKey, result);
   return result;
+}
+
+interface ScryfallCollectionResponse {
+  object: 'list';
+  data: ScryfallCard[];
+}
+
+/**
+ * Fetch many cards by exact name using Scryfall's collection endpoint.
+ * Uses chunking to respect Scryfall's 75 identifiers/request limit.
+ */
+export async function getCardsByExactNames(names: string[]): Promise<ScryfallCard[]> {
+  if (names.length === 0) return [];
+
+  const uniqueNames = [...new Set(names.map((name) => name.trim()).filter(Boolean))];
+  const chunks: string[][] = [];
+
+  for (let i = 0; i < uniqueNames.length; i += 75) {
+    chunks.push(uniqueNames.slice(i, i + 75));
+  }
+
+  const cards: ScryfallCard[] = [];
+
+  for (const chunk of chunks) {
+    const response = await fetchWithRetry(`${BASE_URL}/cards/collection`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'omit',
+      body: JSON.stringify({
+        identifiers: chunk.map((name) => ({ name })),
+      }),
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) continue;
+      throw new Error(`Collection fetch failed: ${response.statusText}`);
+    }
+
+    const result = await response.json() as ScryfallCollectionResponse;
+    cards.push(...result.data);
+  }
+
+  return cards;
 }
 
 /**

--- a/src/lib/scryfall/index.ts
+++ b/src/lib/scryfall/index.ts
@@ -8,6 +8,7 @@ export {
   autocomplete,
   getRandomCard,
   getCardByName,
+  getCardsByExactNames,
   getCardImage,
   isDoubleFacedCard,
   getCardFaceDetails,

--- a/src/pages/PublicDeckView.tsx
+++ b/src/pages/PublicDeckView.tsx
@@ -20,7 +20,7 @@ import { DeckStatsBar } from '@/components/deckbuilder/DeckStats';
 import { CATEGORIES } from '@/components/deckbuilder/constants';
 import { FORMAT_LABELS } from '@/data/formats';
 import { FORMATS } from '@/data/formats';
-import { searchCards } from '@/lib/scryfall';
+import { getCardsByExactNames } from '@/lib/scryfall';
 import { useAuth } from '@/hooks/useAuth';
 import type { Deck, DeckCard } from '@/hooks/useDeck';
 import type { ScryfallCard } from '@/types/card';
@@ -128,7 +128,10 @@ function usePublicDeckCards(deckId: string | undefined) {
   });
 }
 
-/** Progressively fetch Scryfall data for all cards. */
+/**
+ * Hydrate Scryfall card metadata for deck cards in one collection request.
+ * This prevents incremental UI pop-in when opening decks from /decks.
+ */
 function useScryfallHydration(cards: DeckCard[]) {
   const [scryfallMap, setScryfallMap] = useState<Map<string, ScryfallCard>>(new Map());
   const [version, setVersion] = useState(0);
@@ -136,31 +139,33 @@ function useScryfallHydration(cards: DeckCard[]) {
 
   useEffect(() => {
     if (cards.length === 0) return;
+
     let cancelled = false;
     const names = [...new Set(cards.map((c) => c.card_name))];
     const missing = names.filter((n) => !fetchedRef.current.has(n));
+    if (missing.length === 0) return;
 
-    const fetchBatch = async (batch: string[]) => {
-      for (const name of batch) {
-        if (cancelled) return;
-        fetchedRef.current.add(name);
-        try {
-          const res = await searchCards(`!"${name}"`);
-          const sc = res.data?.[0];
-          if (sc) {
-            setScryfallMap((prev) => {
-              const next = new Map(prev);
-              next.set(name, sc);
-              return next;
-            });
-            setVersion((v) => v + 1);
+    missing.forEach((name) => fetchedRef.current.add(name));
+
+    const fetchAll = async () => {
+      try {
+        const fetchedCards = await getCardsByExactNames(missing);
+        if (cancelled || fetchedCards.length === 0) return;
+
+        setScryfallMap((prev) => {
+          const next = new Map(prev);
+          for (const card of fetchedCards) {
+            next.set(card.name, card);
           }
-        } catch { /* silent */ }
-        await new Promise((r) => setTimeout(r, 80));
+          return next;
+        });
+        setVersion((v) => v + 1);
+      } catch {
+        // Keep deck usable even if metadata hydration fails.
       }
     };
 
-    fetchBatch(missing);
+    void fetchAll();
     return () => { cancelled = true; };
   }, [cards]);
 

--- a/src/tests/e2e/decks.spec.ts
+++ b/src/tests/e2e/decks.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+async function openFirstPublicDeck(page: import('@playwright/test').Page) {
+  await page.goto('/decks');
+  await page.waitForLoadState('domcontentloaded');
+
+  const deckLinks = page.locator('a[href^="/deck/"]');
+  const deckCount = await deckLinks.count();
+  test.skip(deckCount === 0, 'No public decks available in this environment');
+
+  await deckLinks.first().click();
+  await page.waitForURL(/\/deck\//);
+  await page.waitForLoadState('networkidle');
+
+  const deckNotFound = page.getByText("Deck not found");
+  test.skip(await deckNotFound.isVisible(), 'Public deck became unavailable');
+}
+
+test.describe('Deck page hydration', () => {
+  test('uses Scryfall collection hydration when opening a deck from /decks', async ({ page }) => {
+    const scryfallSearchRequests: string[] = [];
+    const scryfallCollectionRequests: string[] = [];
+
+    page.on('request', (req) => {
+      const url = req.url();
+      if (!url.includes('api.scryfall.com')) return;
+      if (url.includes('/cards/search')) scryfallSearchRequests.push(url);
+      if (url.includes('/cards/collection')) scryfallCollectionRequests.push(url);
+    });
+
+    await openFirstPublicDeck(page);
+
+    const cardRows = page.locator('li:has-text("1")').first();
+    await expect(cardRows).toBeVisible({ timeout: 15_000 });
+
+    await expect.poll(() => scryfallCollectionRequests.length, {
+      timeout: 15_000,
+      message: 'Expected batched Scryfall collection hydration request',
+    }).toBeGreaterThan(0);
+
+    expect(scryfallSearchRequests).toHaveLength(0);
+  });
+
+  test('public deck view has no critical or serious accessibility violations @a11y', async ({ page }) => {
+    await openFirstPublicDeck(page);
+
+    const results = await new AxeBuilder({ page })
+      .withTags(['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'])
+      .analyze();
+
+    const criticalOrSerious = results.violations.filter(
+      (v) => v.impact === 'critical' || v.impact === 'serious',
+    );
+
+    if (criticalOrSerious.length > 0) {
+      const summary = criticalOrSerious
+        .map((v) => `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`)
+        .join('\n');
+      // eslint-disable-next-line no-console
+      console.error('Deck view accessibility violations:\n' + summary);
+    }
+
+    expect(criticalOrSerious).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Switched public deck hydration in `src/pages/PublicDeckView.tsx` from per-card `searchCards` calls to a batched metadata fetch path.
- Added `getCardsByExactNames` in `src/lib/scryfall/client.ts` to call Scryfall’s `/cards/collection` endpoint with chunking (75 identifiers/request).
- Exported the new helper through `src/lib/scryfall/index.ts`.
- Added Playwright coverage in `src/tests/e2e/decks.spec.ts`:
  - E2E behavior test to verify deck opening from `/decks` uses collection hydration (and avoids per-card search requests).
  - A11y test (`@a11y`) for public deck view with axe critical/serious checks.

## Why
Opening a deck from `/decks` previously hydrated card metadata progressively with one request per card and an artificial delay, causing visible data pop-in. Batched hydration reduces request fanout and makes deck data ready much faster.

## Validation
- `npm run typecheck` ✅
- `npm run test -- src/lib/scryfall/client.test.ts` ⚠️ (failed in this environment because `vitest` binary is unavailable / dependencies are not installed)

## Risk / Notes
- Public deck pages now rely on Scryfall collection endpoint behavior for batched card-name lookups.
- Existing graceful fallback remains: if metadata hydration fails, deck content still renders from DB-backed card rows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a537c96a4883308e78d7d52ed6435d)