### PR TITLE
Reduce client search timeout to 3.5s and add fast-timeout telemetry

### DIFF
--- a/src/hooks/__tests__/useSearchHandler.test.ts
+++ b/src/hooks/__tests__/useSearchHandler.test.ts
@@ -20,8 +20,7 @@ vi.mock('@/hooks/useSearchQuery', () => ({
 
 const mockBuildClientFallbackQuery = vi.fn((q: string) => `o:"${q}"`);
 vi.mock('@/lib/search/fallback', () => ({
-  buildClientFallbackQuery: (q: string) =>
-    mockBuildClientFallbackQuery(q),
+  buildClientFallbackQuery: (q: string) => mockBuildClientFallbackQuery(q),
 }));
 
 vi.mock('sonner', () => ({
@@ -36,11 +35,18 @@ vi.mock('@/lib/core/logger', () => ({
 import { useSearchHandler } from '@/hooks/useSearchHandler';
 import { toast } from 'sonner';
 
-const mockToast = toast as unknown as { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+const mockToast = toast as unknown as {
+  success: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+};
 
 // ── Helpers ────────────────────────────────────────────────
 
-type OnSearchFn = (query: string, result?: SearchResult, naturalQuery?: string) => void;
+type OnSearchFn = (
+  query: string,
+  result?: SearchResult,
+  naturalQuery?: string,
+) => void;
 
 function createOptions(overrides?: Record<string, unknown>) {
   return {
@@ -90,7 +96,9 @@ describe('useSearchHandler', () => {
       await result.current.handleSearch();
     });
 
-    expect(opts.addToHistory).toHaveBeenCalledWith('creatures that make treasure');
+    expect(opts.addToHistory).toHaveBeenCalledWith(
+      'creatures that make treasure',
+    );
   });
 
   // 3. Saves context
@@ -148,9 +156,9 @@ describe('useSearchHandler', () => {
       searchPromise = result.current.handleSearch();
     });
 
-    // Advance past the search timeout (15s) outside of act
+    // Advance past the fast search timeout (3.5s) outside of act
     await act(async () => {
-      vi.advanceTimersByTime(16000);
+      vi.advanceTimersByTime(4000);
     });
 
     await act(async () => {
@@ -160,9 +168,34 @@ describe('useSearchHandler', () => {
     expect(opts.onSearch).toHaveBeenCalledTimes(1);
     const [, searchResult] = opts.onSearch.mock.calls[0];
     expect(searchResult!.source).toBe('client_fallback');
-    expect(mockBuildClientFallbackQuery).toHaveBeenCalledWith('creatures that make treasure');
-    expect(mockToast.error).toHaveBeenCalled();
-  }, 15000);
+    expect(mockBuildClientFallbackQuery).toHaveBeenCalledTimes(1);
+    expect(mockBuildClientFallbackQuery).toHaveBeenCalledWith(
+      'creatures that make treasure',
+    );
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers timeout fallback exactly once per timed-out request token', async () => {
+    const neverResolvingPromise = new Promise(() => {});
+    mockTranslateQueryWithDedup.mockReturnValue(neverResolvingPromise);
+
+    const opts = createOptions();
+    const { result } = renderHook(() => useSearchHandler(opts));
+
+    let searchPromise: Promise<void>;
+    act(() => {
+      searchPromise = result.current.handleSearch();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(4000);
+      await searchPromise!;
+    });
+
+    expect(opts.onSearch).toHaveBeenCalledTimes(1);
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+    expect(mockBuildClientFallbackQuery).toHaveBeenCalledTimes(1);
+  });
 
   // 7. Error fallback
   it('falls back to client query on generic error', async () => {
@@ -183,7 +216,9 @@ describe('useSearchHandler', () => {
 
   // 8. Rate limit handling (429)
   it('sets rate limit on 429 error and blocks subsequent searches', async () => {
-    mockTranslateQueryWithDedup.mockRejectedValue(new Error('429 Too Many Requests'));
+    mockTranslateQueryWithDedup.mockRejectedValue(
+      new Error('429 Too Many Requests'),
+    );
 
     const opts = createOptions();
     const { result } = renderHook(() => useSearchHandler(opts));
@@ -238,7 +273,9 @@ describe('useSearchHandler', () => {
   // 11. Request cancellation (stale token)
   it('ignores stale response when a newer search is triggered', async () => {
     let resolveFirst: (v: unknown) => void;
-    const firstPromise = new Promise((r) => { resolveFirst = r; });
+    const firstPromise = new Promise((r) => {
+      resolveFirst = r;
+    });
     const secondResult = createMockTranslation({
       scryfallQuery: 't:artifact',
       source: 'ai',
@@ -401,12 +438,17 @@ describe('useSearchHandler', () => {
 
     expect(mockTranslateQueryWithDedup).not.toHaveBeenCalled();
     expect(opts.onSearch).not.toHaveBeenCalled();
-    expect(mockToast.error).toHaveBeenCalledWith('Please wait', expect.any(Object));
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'Please wait',
+      expect.any(Object),
+    );
   });
 
   // 18. Rate limit expires and search resumes
   it('allows search after rate limit window expires', async () => {
-    mockTranslateQueryWithDedup.mockRejectedValueOnce(new Error('Rate limit exceeded'));
+    mockTranslateQueryWithDedup.mockRejectedValueOnce(
+      new Error('Rate limit exceeded'),
+    );
     const opts = createOptions();
     const { result } = renderHook(() => useSearchHandler(opts));
 
@@ -460,9 +502,10 @@ describe('useSearchHandler', () => {
   // 21. Concurrent timeout and error — timeout fires first
   it('timeout wins over slow rejection', async () => {
     mockTranslateQueryWithDedup.mockImplementation(
-      () => new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('Slow error')), 120000);
-      }),
+      () =>
+        new Promise((_, reject) => {
+          setTimeout(() => reject(new Error('Slow error')), 120000);
+        }),
     );
 
     const opts = createOptions();
@@ -474,7 +517,7 @@ describe('useSearchHandler', () => {
     });
 
     await act(async () => {
-      vi.advanceTimersByTime(16000);
+      vi.advanceTimersByTime(4000);
     });
 
     await act(async () => {
@@ -487,14 +530,15 @@ describe('useSearchHandler', () => {
       'Search took too long',
       expect.any(Object),
     );
-  }, 15000);
+    expect(mockToast.error).toHaveBeenCalledTimes(1);
+  });
 
   // 22. Multiple error variants trigger correct fallback path
   it.each([
-    ['Please wait before retrying', true],  // rate-limit variant
-    ['rate limited by server', true],        // rate-limit variant
-    ['Server returned 500', false],          // generic error
-    ['ECONNREFUSED', false],                 // network error
+    ['Please wait before retrying', true], // rate-limit variant
+    ['rate limited by server', true], // rate-limit variant
+    ['Server returned 500', false], // generic error
+    ['ECONNREFUSED', false], // network error
   ])('error "%s" → rate-limited=%s', async (msg, isRateLimited) => {
     mockTranslateQueryWithDedup.mockRejectedValue(new Error(msg));
     const opts = createOptions();

--- a/src/hooks/useSearchHandler.ts
+++ b/src/hooks/useSearchHandler.ts
@@ -6,7 +6,10 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { toast } from 'sonner';
 import { logger } from '@/lib/core/logger';
-import { translateQueryWithDedup, type TranslationResult } from '@/hooks/useSearchQuery';
+import {
+  translateQueryWithDedup,
+  type TranslationResult,
+} from '@/hooks/useSearchQuery';
 import { buildClientFallbackQuery } from '@/lib/search/fallback';
 import { CLIENT_CONFIG } from '@/lib/config';
 import type { FilterState } from '@/types/filters';
@@ -176,6 +179,8 @@ export function useSearchHandler({
           const fallbackQuery = buildClientFallbackQuery(queryToSearch);
           logger.warn('[SearchDiag] FALLBACK: timeout', {
             query: queryToSearch,
+            timeoutBehavior: 'fast_timeout',
+            timeoutTriggered: true,
             timeoutMs: CLIENT_CONFIG.SEARCH_TIMEOUT_MS,
             responseMs,
             fallbackQuery,
@@ -183,23 +188,32 @@ export function useSearchHandler({
           toast.error('Search took too long', {
             description: 'Using simplified search instead',
           });
-          onSearch(fallbackQuery, {
-            scryfallQuery: fallbackQuery,
-            explanation: {
-              readable: `Searching for: ${queryToSearch}`,
-              assumptions: ['Search timed out — using simplified translation'],
-              confidence: 0.5,
+          onSearch(
+            fallbackQuery,
+            {
+              scryfallQuery: fallbackQuery,
+              explanation: {
+                readable: `Searching for: ${queryToSearch}`,
+                assumptions: [
+                  'Search timed out — using simplified translation',
+                ],
+                confidence: 0.5,
+              },
+              showAffiliate: false,
+              source: 'client_fallback',
             },
-            showAffiliate: false,
-            source: 'client_fallback',
-          }, queryToSearch);
+            queryToSearch,
+          );
         } else if (
           errorMessage.includes('429') ||
           errorMessage.includes('rate') ||
           errorMessage.includes('Rate limit') ||
           errorMessage.includes('Please wait')
         ) {
-          logger.warn('[SearchDiag] Rate limited', { query: queryToSearch, error: errorMessage });
+          logger.warn('[SearchDiag] Rate limited', {
+            query: queryToSearch,
+            error: errorMessage,
+          });
           setRateLimitedUntil(Date.now() + 30000);
           toast.error('Too many searches', {
             description: 'Please wait a moment before searching again',
@@ -215,16 +229,20 @@ export function useSearchHandler({
           toast.error('Search issue', {
             description: 'Using simplified search instead',
           });
-          onSearch(fallbackQuery, {
-            scryfallQuery: fallbackQuery,
-            explanation: {
-              readable: `Searching for: ${queryToSearch}`,
-              assumptions: ['AI unavailable — using simplified translation'],
-              confidence: 0.5,
+          onSearch(
+            fallbackQuery,
+            {
+              scryfallQuery: fallbackQuery,
+              explanation: {
+                readable: `Searching for: ${queryToSearch}`,
+                assumptions: ['AI unavailable — using simplified translation'],
+                confidence: 0.5,
+              },
+              showAffiliate: false,
+              source: 'client_fallback',
             },
-            showAffiliate: false,
-            source: 'client_fallback',
-          }, queryToSearch);
+            queryToSearch,
+          );
         }
       } finally {
         setIsSearching(false);
@@ -232,14 +250,7 @@ export function useSearchHandler({
         abortControllerRef.current = null;
       }
     },
-    [
-      addToHistory,
-      filters,
-      onSearch,
-      query,
-      rateLimitedUntil,
-      saveContext,
-    ],
+    [addToHistory, filters, onSearch, query, rateLimitedUntil, saveContext],
   );
 
   return {

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -12,7 +12,7 @@ describe('CLIENT_CONFIG', () => {
   });
 
   it('exports search settings', () => {
-    expect(CLIENT_CONFIG.SEARCH_TIMEOUT_MS).toBe(25000);
+    expect(CLIENT_CONFIG.SEARCH_TIMEOUT_MS).toBe(3500);
     expect(CLIENT_CONFIG.SEARCH_DEBOUNCE_MS).toBe(300);
   });
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,7 +8,7 @@ export const CLIENT_CONFIG = {
   VIRTUALIZATION_THRESHOLD: 50,
 
   // Search settings
-  SEARCH_TIMEOUT_MS: 25000, // 25 seconds
+  SEARCH_TIMEOUT_MS: 3500, // 3.5 seconds
   SEARCH_DEBOUNCE_MS: 300,
 
   // Cache settings


### PR DESCRIPTION
### Motivation
- Align client search timeout with a faster UX target by reducing the translation timeout threshold and make timeout telemetry explicit so logs can distinguish fast-timeout behavior.

### Description
- Lowered `CLIENT_CONFIG.SEARCH_TIMEOUT_MS` from `25000` to `3500` in `src/lib/config.ts`.
- Added explicit timeout telemetry fields (`timeoutBehavior: 'fast_timeout'`, `timeoutTriggered: true`) in the `Search timeout` fallback log in `src/hooks/useSearchHandler.ts` while keeping the existing fallback behavior unchanged.
- Updated assertions in `src/lib/config.test.ts` to expect the new timeout value and adjusted multiple timeout-related tests in `src/hooks/__tests__/useSearchHandler.test.ts` to use the shorter timing (`vi.advanceTimersByTime(4000)`) and stronger assertions.
- Added a dedicated test to ensure the toast/fallback behavior triggers exactly once per timed-out request token and tightened counts on related toast/fallback mocks.

### Testing
- Ran `bun run test -- src/lib/config.test.ts src/hooks/__tests__/useSearchHandler.test.ts` and both test files passed (all tests green).
- The modified `useSearchHandler` test suite verifies timeout fallback, single-execution of fallback/toast per timed-out token, rate-limit handling, and other existing behaviors successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a538d4ee6c8330a0a4b22fc04a622b)