### PR TITLE
Tighten pre-translation gating and add telemetry to semantic-search

### DIFF
--- a/supabase/functions/semantic-search/index.ts
+++ b/supabase/functions/semantic-search/index.ts
@@ -11,7 +11,7 @@ import {
   setPersistentCache,
   maybeCacheCleanup,
 } from './cache.ts';
-import { fetchWithRetry } from './utils.ts';
+import { fetchWithRetry, fetchWithTimeout } from './utils.ts';
 import {
   isCircuitOpen,
   recordCircuitFailure,
@@ -49,7 +49,7 @@ function isRawScryfallSyntax(query: string): boolean {
 
   // Extract all tokens that look like operators
   const tokens = query.split(/\s+/);
-  const operatorTokens = tokens.filter(t => /^-?[a-zA-Z]+[:=<>]/.test(t));
+  const operatorTokens = tokens.filter((t) => /^-?[a-zA-Z]+[:=<>]/.test(t));
 
   // If most tokens are operator-based, it's raw syntax
   if (operatorTokens.length === 0) return false;
@@ -59,18 +59,59 @@ function isRawScryfallSyntax(query: string): boolean {
     const keyMatch = token.match(/^-?([a-zA-Z]+)[:=<>]/);
     if (keyMatch) {
       const key = keyMatch[1].toLowerCase();
-      if (!VALID_SEARCH_KEYS.has(key) && !['kw', 'otag', 'atag', 'in', 'is', 'not', 'has', 'set', 'cn', 'year', 'game', 'banned', 'restricted', 'unique', 'order', 'direction', 'prefer', 'prints', 'new', 'cheapest', 'usd', 'eur', 'tix', 'border', 'frame', 'stamp', 'watermark', 'art', 'flavor', 'lore', 'include', 'language', 'date', 'mana', 'wildpair'].includes(key)) {
+      if (
+        !VALID_SEARCH_KEYS.has(key) &&
+        ![
+          'kw',
+          'otag',
+          'atag',
+          'in',
+          'is',
+          'not',
+          'has',
+          'set',
+          'cn',
+          'year',
+          'game',
+          'banned',
+          'restricted',
+          'unique',
+          'order',
+          'direction',
+          'prefer',
+          'prints',
+          'new',
+          'cheapest',
+          'usd',
+          'eur',
+          'tix',
+          'border',
+          'frame',
+          'stamp',
+          'watermark',
+          'art',
+          'flavor',
+          'lore',
+          'include',
+          'language',
+          'date',
+          'mana',
+          'wildpair',
+        ].includes(key)
+      ) {
         return false; // Contains invalid operator
       }
     }
   }
 
   // Non-operator words should be minimal (allow OR, AND, NOT, parens, quotes)
-  const nonOperatorTokens = tokens.filter(t =>
-    !(/^-?[a-zA-Z]+[:=<>]/.test(t)) &&
-    !['or', 'and', 'not', '-'].includes(t.toLowerCase()) &&
-    !t.startsWith('(') && !t.startsWith(')') &&
-    !t.startsWith('"')
+  const nonOperatorTokens = tokens.filter(
+    (t) =>
+      !/^-?[a-zA-Z]+[:=<>]/.test(t) &&
+      !['or', 'and', 'not', '-'].includes(t.toLowerCase()) &&
+      !t.startsWith('(') &&
+      !t.startsWith(')') &&
+      !t.startsWith('"'),
   );
 
   // If more than 30% of tokens are natural language, it's not raw syntax
@@ -81,7 +122,11 @@ function isRawScryfallSyntax(query: string): boolean {
  * Auto-seed high-confidence AI translations into translation_rules
  * so future identical queries hit the pattern match layer instead of AI.
  */
-async function seedTranslationRule(query: string, scryfallQuery: string, confidence: number): Promise<void> {
+async function seedTranslationRule(
+  query: string,
+  scryfallQuery: string,
+  confidence: number,
+): Promise<void> {
   try {
     const normalized = query.toLowerCase().trim().replace(/\s+/g, ' ');
     // Don't seed very short or very long queries
@@ -95,7 +140,7 @@ async function seedTranslationRule(query: string, scryfallQuery: string, confide
         description: `Auto-seeded from AI translation`,
         is_active: true,
       },
-      { onConflict: 'pattern' }
+      { onConflict: 'pattern' },
     );
   } catch {
     // Silently fail - this is an optimization, not critical
@@ -142,6 +187,11 @@ function sanitizeError(error: unknown): string {
   }
   return 'Unknown error';
 }
+
+const REQUEST_LATENCY_BUDGET_MS = 15_000;
+const PRE_TRANSLATION_MIN_REMAINING_BUDGET_MS = 4_000;
+const PRE_TRANSLATION_TIMEOUT_MS = 2_500;
+const ACCENTED_LATIN_HIGH_CONFIDENCE_THRESHOLD = 0.9;
 
 /**
  * Main Edge Function Handler
@@ -358,17 +408,37 @@ serve(async (req) => {
     // 2.5. Fast-path for short, likely card-name queries (skip cache/pattern/AI entirely)
     // Card names are 1-6 title-cased words with no search keywords — deterministic is instant.
     const queryWords = query.trim().split(/\s+/);
-    const isFastNameCandidate = queryWords.length <= 6 && queryWords.length >= 1
-      && queryWords.every((w: string) => /^[A-Z]/.test(w) || /^(of|the|and|to|in|for|a|an)$/i.test(w))
-      && !/\b(with|that|under|below|above|less|more|cheap|budget|from|legal|commander|deck|spells?|cards?|creatures?|artifacts?|enchantments?|lands?|instants?|sorcery|sorceries)\b/i.test(query);
+    const isFastNameCandidate =
+      queryWords.length <= 6 &&
+      queryWords.length >= 1 &&
+      queryWords.every(
+        (w: string) =>
+          /^[A-Z]/.test(w) || /^(of|the|and|to|in|for|a|an)$/i.test(w),
+      ) &&
+      !/\b(with|that|under|below|above|less|more|cheap|budget|from|legal|commander|deck|spells?|cards?|creatures?|artifacts?|enchantments?|lands?|instants?|sorcery|sorceries)\b/i.test(
+        query,
+      );
 
     if (isFastNameCandidate) {
       const fastResult = buildDeterministicIntent(query);
-      const fastQuery = applyFiltersToQuery(fastResult.deterministicQuery, filters);
+      const fastQuery = applyFiltersToQuery(
+        fastResult.deterministicQuery,
+        filters,
+      );
       if (fastQuery && !fastResult.intent.remainingQuery) {
         const validation = validateQuery(fastQuery);
         const responseTimeMs = Date.now() - requestStartTime;
-        logTranslation(query, validation.sanitized, 0.9, responseTimeMs, [], [], filters, false, 'deterministic');
+        logTranslation(
+          query,
+          validation.sanitized,
+          0.9,
+          responseTimeMs,
+          [],
+          [],
+          filters,
+          false,
+          'deterministic',
+        );
         flushLogQueue();
 
         return new Response(
@@ -460,7 +530,17 @@ serve(async (req) => {
       if (cached) {
         const responseTimeMs = Date.now() - requestStartTime;
         logInfo('cache_hit', { query: query.substring(0, 50), responseTimeMs });
-        logTranslation(query, cached.scryfallQuery, cached.explanation?.confidence ?? 0.9, responseTimeMs, [], [], filters, false, 'cache');
+        logTranslation(
+          query,
+          cached.scryfallQuery,
+          cached.explanation?.confidence ?? 0.9,
+          responseTimeMs,
+          [],
+          [],
+          filters,
+          false,
+          'cache',
+        );
         flushLogQueue(); // fire-and-forget — don't block the response
 
         return new Response(
@@ -487,7 +567,17 @@ serve(async (req) => {
       });
 
       setCachedResult(query, filters, patternMatch, cacheSalt);
-      logTranslation(query, patternMatch.scryfallQuery, patternMatch.explanation?.confidence ?? 0.85, responseTimeMs, [], [], filters, false, 'pattern_match');
+      logTranslation(
+        query,
+        patternMatch.scryfallQuery,
+        patternMatch.explanation?.confidence ?? 0.85,
+        responseTimeMs,
+        [],
+        [],
+        filters,
+        false,
+        'pattern_match',
+      );
       flushLogQueue(); // fire-and-forget
 
       return new Response(
@@ -533,8 +623,21 @@ serve(async (req) => {
     if (isRawScryfallSyntax(trimmedQuery)) {
       const validation = validateQuery(trimmedQuery);
       const responseTimeMs = Date.now() - requestStartTime;
-      logInfo('raw_syntax_passthrough', { query: trimmedQuery.substring(0, 50), responseTimeMs });
-      logTranslation(query, validation.sanitized, 0.95, responseTimeMs, [], [], filters, false, 'raw_syntax');
+      logInfo('raw_syntax_passthrough', {
+        query: trimmedQuery.substring(0, 50),
+        responseTimeMs,
+      });
+      logTranslation(
+        query,
+        validation.sanitized,
+        0.95,
+        responseTimeMs,
+        [],
+        [],
+        filters,
+        false,
+        'raw_syntax',
+      );
       flushLogQueue(); // fire-and-forget
 
       const rawResult = {
@@ -566,7 +669,17 @@ serve(async (req) => {
     if (deterministicQuery && !deterministicResult.intent.remainingQuery) {
       const validation = validateQuery(deterministicQuery || query);
       const responseTimeMs = Date.now() - requestStartTime;
-      logTranslation(query, validation.sanitized, 0.9, responseTimeMs, [], [], filters, false, 'deterministic');
+      logTranslation(
+        query,
+        validation.sanitized,
+        0.9,
+        responseTimeMs,
+        [],
+        [],
+        filters,
+        false,
+        'deterministic',
+      );
       flushLogQueue(); // fire-and-forget
 
       return new Response(
@@ -588,54 +701,100 @@ serve(async (req) => {
     // 7. Pre-translate non-English queries to English for better AI accuracy
     const remainingQuery = deterministicResult.intent.remainingQuery || '';
     let queryForAI = remainingQuery;
+    let preTranslationAttempted = false;
+    let preTranslationSkippedReason: string | null = null;
 
-    // Detect non-Latin scripts or common non-English patterns
-    const hasNonLatin = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Cyrillic}\p{Script=Arabic}\p{Script=Devanagari}]/u.test(remainingQuery);
-    const hasAccentedLatin = /[àáâãäåæçèéêëìíîïðñòóôõöùúûüýþÿ]/i.test(remainingQuery);
-    const looksNonEnglish = hasNonLatin || (hasAccentedLatin && !/^[a-zA-Z0-9\s\-:=<>!'"()+/*.,;$]+$/.test(remainingQuery));
+    // Detect stronger non-English signals
+    const hasNonLatin =
+      /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Cyrillic}\p{Script=Arabic}\p{Script=Devanagari}]/u.test(
+        remainingQuery,
+      );
+    const hasAccentedLatin = /[àáâãäåæçèéêëìíîïðñòóôõöùúûüýþÿ]/i.test(
+      remainingQuery,
+    );
+    const deterministicConfidence = deterministicResult.intent.confidence ?? 0;
+    const shouldPreTranslateAccentedLatin =
+      hasAccentedLatin &&
+      !hasNonLatin &&
+      deterministicConfidence >= ACCENTED_LATIN_HIGH_CONFIDENCE_THRESHOLD;
+    const looksNonEnglish = hasNonLatin || shouldPreTranslateAccentedLatin;
 
     if (looksNonEnglish && remainingQuery.trim().length > 0) {
-      try {
-        const preTranslateResponse = await fetchWithRetry(
-          'https://ai.gateway.lovable.dev/v1/chat/completions',
-          {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${LOVABLE_API_KEY}`,
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              model: 'google/gemini-2.5-flash-lite',
-              messages: [
-                {
-                  role: 'system',
-                  content: 'You are a translator. Translate the following Magic: The Gathering card search query into English. Preserve all MTG-specific intent (counter, destroy, exile, ramp, etc.). Output ONLY the English translation, nothing else.',
-                },
-                { role: 'user', content: remainingQuery },
-              ],
-              temperature: 0.0,
-            }),
-          },
-        );
+      const elapsedBeforePreTranslationMs = Date.now() - requestStartTime;
+      const remainingBudgetMs =
+        REQUEST_LATENCY_BUDGET_MS - elapsedBeforePreTranslationMs;
 
-        if (preTranslateResponse.ok) {
-          const preTranslateData = await preTranslateResponse.json();
-          const translated = preTranslateData?.choices?.[0]?.message?.content?.trim();
-          if (translated && translated.length > 0) {
-            logInfo(`Pre-translated: "${remainingQuery}" → "${translated}"`);
-            queryForAI = translated;
+      if (remainingBudgetMs < PRE_TRANSLATION_MIN_REMAINING_BUDGET_MS) {
+        preTranslationSkippedReason = 'low_remaining_budget';
+      } else {
+        preTranslationAttempted = true;
+        try {
+          const preTranslateResponse = await fetchWithTimeout(
+            'https://ai.gateway.lovable.dev/v1/chat/completions',
+            {
+              method: 'POST',
+              headers: {
+                Authorization: `Bearer ${LOVABLE_API_KEY}`,
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify({
+                model: 'google/gemini-2.5-flash-lite',
+                messages: [
+                  {
+                    role: 'system',
+                    content:
+                      'You are a translator. Translate the following Magic: The Gathering card search query into English. Preserve all MTG-specific intent (counter, destroy, exile, ramp, etc.). Output ONLY the English translation, nothing else.',
+                  },
+                  { role: 'user', content: remainingQuery },
+                ],
+                temperature: 0.0,
+              }),
+            },
+            PRE_TRANSLATION_TIMEOUT_MS,
+          );
+
+          if (preTranslateResponse.ok) {
+            const preTranslateData = await preTranslateResponse.json();
+            const translated =
+              preTranslateData?.choices?.[0]?.message?.content?.trim();
+            if (translated && translated.length > 0) {
+              logInfo('pre_translation_applied', {
+                preTranslationAttempted,
+                preTranslationSkippedReason,
+              });
+              queryForAI = translated;
+            } else {
+              preTranslationSkippedReason = 'empty_translation';
+            }
+          } else {
+            preTranslationSkippedReason = 'gateway_non_ok';
           }
+        } catch (e) {
+          // Pre-translation failed, proceed with original query without retries.
+          preTranslationSkippedReason =
+            e instanceof Error && e.name === 'AbortError'
+              ? 'pre_translation_timeout'
+              : 'pre_translation_failure';
+          logWarn('pre_translation_failed', {
+            error: sanitizeError(e),
+            preTranslationAttempted,
+            preTranslationSkippedReason,
+          });
         }
-      } catch (e) {
-        // Pre-translation failed, proceed with original query
-        logWarn(`Pre-translation failed, using original: ${e}`);
       }
+    } else if (remainingQuery.trim().length === 0) {
+      preTranslationSkippedReason = 'empty_remaining_query';
+    } else if (hasAccentedLatin && !shouldPreTranslateAccentedLatin) {
+      preTranslationSkippedReason = 'accented_latin_low_confidence';
+    } else {
+      preTranslationSkippedReason = 'no_strong_non_english_signal';
     }
 
     // 8. AI Translation (with tiered model selection)
     // Fetch dynamic rules in parallel with building context (non-blocking)
     const queryWordCount = query.trim().split(/\s+/).length;
-    const isLikelyName = deterministicResult.intent.warnings.includes('likely_card_name');
+    const isLikelyName =
+      deterministicResult.intent.warnings.includes('likely_card_name');
     const tier: QueryTier =
       queryWordCount > 8 ? 'complex' : queryWordCount > 4 ? 'medium' : 'simple';
 
@@ -719,7 +878,9 @@ serve(async (req) => {
 
       // Auto-seed high-confidence AI translations into translation_rules for future pattern matches
       if (confidence >= 0.8 && validation.sanitized.length > 0) {
-        seedTranslationRule(query, validation.sanitized, confidence).catch(() => {});
+        seedTranslationRule(query, validation.sanitized, confidence).catch(
+          () => {},
+        );
       }
 
       logTranslation(
@@ -731,7 +892,18 @@ serve(async (req) => {
         qualityFlags,
         filters,
         false,
+        'ai',
+        null,
+        {
+          preTranslationAttempted,
+          preTranslationSkippedReason,
+        },
       );
+      logInfo('ai_translation_success', {
+        responseTimeMs,
+        preTranslationAttempted,
+        preTranslationSkippedReason,
+      });
       flushLogQueue(); // fire-and-forget
 
       return new Response(
@@ -747,7 +919,11 @@ serve(async (req) => {
       );
     } catch (e) {
       recordCircuitFailure();
-      logWarn('ai_failure', { error: sanitizeError(e) });
+      logWarn('ai_failure', {
+        error: sanitizeError(e),
+        preTranslationAttempted,
+        preTranslationSkippedReason,
+      });
       const fallback = buildFallbackQuery(query, filters);
       return new Response(
         JSON.stringify({

--- a/supabase/functions/semantic-search/logging.ts
+++ b/supabase/functions/semantic-search/logging.ts
@@ -12,6 +12,13 @@ export interface LogEntry {
   fallback_used: boolean;
   source: string;
   result_count: number | null;
+  pre_translation_attempted: boolean;
+  pre_translation_skipped_reason: string | null;
+}
+
+interface PreTranslationTelemetry {
+  preTranslationAttempted: boolean;
+  preTranslationSkippedReason: string | null;
 }
 
 const logQueue: LogEntry[] = [];
@@ -53,6 +60,7 @@ export function logTranslation(
   fallbackUsed: boolean,
   source: string = 'ai',
   resultCount: number | null = null,
+  preTranslationTelemetry?: PreTranslationTelemetry,
 ): void {
   logQueue.push({
     natural_language_query: naturalQuery.substring(0, 500),
@@ -66,6 +74,10 @@ export function logTranslation(
     fallback_used: fallbackUsed,
     source,
     result_count: resultCount,
+    pre_translation_attempted:
+      preTranslationTelemetry?.preTranslationAttempted ?? false,
+    pre_translation_skipped_reason:
+      preTranslationTelemetry?.preTranslationSkippedReason ?? null,
   });
 
   if (logQueue.length >= LOG_BATCH_SIZE) {


### PR DESCRIPTION
### Motivation
- Reduce latency and unnecessary pre-translation work for edge AI translations by skipping pre-translation when remaining request budget is low and avoid weak non-English heuristics for accented-Latin inputs.
- Improve observability for pre-translation behavior by adding explicit telemetry fields to translation logs for latency analysis and debugging.

### Description
- Add runtime tuning constants `REQUEST_LATENCY_BUDGET_MS`, `PRE_TRANSLATION_MIN_REMAINING_BUDGET_MS`, `PRE_TRANSLATION_TIMEOUT_MS`, and `ACCENTED_LATIN_HIGH_CONFIDENCE_THRESHOLD`, and gate pre-translation with a remaining-budget check before issuing a request.
- Restrict pre-translation triggers to strong non-Latin script signals and only allow accented-Latin pre-translation when deterministic confidence meets `ACCENTED_LATIN_HIGH_CONFIDENCE_THRESHOLD`.
- Replace the retrying pre-translation call with a single timeout-bounded request via `fetchWithTimeout`, and when pre-translation times out or fails it immediately continues with the original query (no retry chain).
- Add telemetry fields to logs by extending `LogEntry` with `pre_translation_attempted` and `pre_translation_skipped_reason`, update `logTranslation` to accept optional pre-translation telemetry, and include telemetry in the AI-success and AI-failure logs and in pre-translation info/warn events.
- Files changed: `supabase/functions/semantic-search/index.ts` and `supabase/functions/semantic-search/logging.ts`.

### Testing
- Ran ESLint on the modified files with `npx eslint supabase/functions/semantic-search/index.ts supabase/functions/semantic-search/logging.ts`, which completed without reported errors.
- Attempted `deno test supabase/functions/semantic-search/index.test.ts`, but `deno` is not available in this environment so tests could not be executed there.
- Attempted `npm run test -- supabase/functions/semantic-search/index.test.ts`, but the local Vitest configuration does not include the `supabase/` path so the edge-function test file was not discovered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a538da59bc83308eadf6dfbce63ff4)