### PR TITLE
ci: gate e2e and a11y with opt-in conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,25 @@ on:
     branches: ['main']
   pull_request:
   schedule:
-    - cron: '0 3 * * *'   # nightly — e2e + a11y
-    - cron: '0 6 * * 1'   # weekly — live Scryfall validation
+    - cron: '0 3 * * *' # nightly — e2e + a11y
+    - cron: '0 6 * * 1' # weekly — live Scryfall validation
   workflow_dispatch:
+    inputs:
+      run_e2e:
+        description: 'Run E2E tests (default: true)'
+        required: false
+        default: true
+        type: boolean
+      run_a11y:
+        description: 'Run accessibility tests (default: true)'
+        required: false
+        default: true
+        type: boolean
 
 # Cancel in-progress runs for the same branch/PR
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: false  # TODO: re-enable once Playwright browser cache is seeded
+  cancel-in-progress: false # TODO: re-enable once Playwright browser cache is seeded
 
 jobs:
   # ─── Shared setup ───────────────────────────────────────────────────
@@ -145,8 +156,12 @@ jobs:
             fi
           fi
 
-  # ─── E2E tests (nightly + on-demand) ───────────────────────────────
+  # ─── E2E tests (nightly + manual + PR opt-in label) ────────────────
   e2e:
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_e2e) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:e2e'))
     needs: install
     runs-on: ubuntu-latest
     steps:
@@ -187,8 +202,12 @@ jobs:
           path: test-results
           retention-days: 7
 
-  # ─── Accessibility tests (nightly) ──────────────────────────────────
+  # ─── Accessibility tests (nightly + manual + PR opt-in label) ──────
   a11y:
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.run_a11y) ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:a11y'))
     needs: install
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
### Motivation

- Ensure `e2e` and `a11y` jobs run by default for scheduled and manual workflows while avoiding mandatory pre-merge cost on every PR.  
- Allow maintainers to opt a PR into `e2e`/`a11y` via labels to enable pre-merge testing for specific changes.  
- Preserve core PR quality gates (`lint`, `typecheck`, `test`, `build`) as mandatory checks.

### Description

- Added `workflow_dispatch` boolean inputs `run_e2e` and `run_a11y` (default `true`) so manual runs can toggle those jobs.  
- Added job-level `if` conditions to `e2e` and `a11y` so they run when the event is `schedule`, when `workflow_dispatch` inputs are enabled, or on `pull_request` only if the PR has the opt-in labels `ci:e2e` / `ci:a11y`.  
- Updated the workflow comments to reflect the new behavior (manual + PR label opt-in) and left the existing mandatory quality gate jobs unchanged.  
- Changes applied to `.github/workflows/ci.yml` to introduce the inputs and the conditional expressions.

### Testing

- Pre-commit formatting (Prettier via lint-staged) ran successfully against the modified YAML file.  
- Ran `git diff --check` to verify there are no whitespace or diff check issues.  
- Attempted a local YAML load with `python` which failed because `PyYAML` is not installed in this environment (`ModuleNotFoundError: No module named 'yaml'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a53cdd03e483308780c5ac9c05f845)