### PR TITLE
test(e2e): use explicit testids and deterministic waits

### DIFF
--- a/src/components/CardImageItem.tsx
+++ b/src/components/CardImageItem.tsx
@@ -29,12 +29,26 @@ export const CardImageItem = memo(function CardImageItem({
     <button
       onClick={onClick}
       tabIndex={tabIndex}
+      data-testid="search-result-card"
       className="relative aspect-[2.5/3.5] rounded-lg overflow-hidden bg-secondary cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-transform duration-200 hover:scale-[1.03] w-full"
       aria-label={`View ${displayName}`}
     >
       {isOwned && (
-        <div className="absolute top-1.5 left-1.5 z-10 h-5 w-5 rounded-full bg-emerald-500/90 flex items-center justify-center shadow-sm" aria-label="Owned">
-          <svg className="h-3 w-3 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+        <div
+          className="absolute top-1.5 left-1.5 z-10 h-5 w-5 rounded-full bg-emerald-500/90 flex items-center justify-center shadow-sm"
+          aria-label="Owned"
+        >
+          <svg
+            className="h-3 w-3 text-white"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
         </div>
       )}
       <img

--- a/src/components/CardListItem.tsx
+++ b/src/components/CardListItem.tsx
@@ -7,7 +7,10 @@ import { memo } from 'react';
 import type { KeyboardEvent } from 'react';
 import type { ScryfallCard } from '@/types/card';
 import { ManaCost } from '@/components/ManaSymbol';
-import { getLocalizedName, getLocalizedTypeLine } from '@/lib/scryfall/localized';
+import {
+  getLocalizedName,
+  getLocalizedTypeLine,
+} from '@/lib/scryfall/localized';
 import { useTranslation } from '@/lib/i18n';
 
 interface CardListItemProps {
@@ -42,13 +45,27 @@ export const CardListItem = memo(function CardListItem({
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={tabIndex}
+      data-testid="search-result-card"
       className="flex items-center gap-3 px-3 py-2 rounded-lg border border-border/50 bg-card/50 hover:bg-muted/50 hover:border-border cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
       aria-label={`View details for ${displayName}`}
     >
       {/* Owned indicator */}
       {isOwned && (
-        <span className="h-4 w-4 rounded-full bg-emerald-500/90 flex items-center justify-center shrink-0" aria-label="Owned">
-          <svg className="h-2.5 w-2.5 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+        <span
+          className="h-4 w-4 rounded-full bg-emerald-500/90 flex items-center justify-center shrink-0"
+          aria-label="Owned"
+        >
+          <svg
+            className="h-2.5 w-2.5 text-white"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
         </span>
       )}
 

--- a/src/components/SearchHelpModal/SearchHelpModal.tsx
+++ b/src/components/SearchHelpModal/SearchHelpModal.tsx
@@ -56,6 +56,7 @@ export function SearchHelpModal({ onTryExample }: SearchHelpModalProps) {
           size="sm"
           className="h-8 px-2 gap-1.5 text-xs rounded-full text-muted-foreground hover:text-foreground"
           aria-label="Search help"
+          data-testid="search-help-trigger"
         >
           <HelpCircle className="h-4 w-4" />
           <span className="hidden sm:inline">{t('help.label')}</span>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -21,6 +21,7 @@ export function ThemeToggle() {
       className="rounded-lg magnetic"
       aria-label={isDark ? t('theme.switchToLight') : t('theme.switchToDark')}
       aria-pressed={isDark}
+      data-testid="theme-toggle"
     >
       <Sun
         className="h-4 w-4 rotate-0 scale-100 transition-all duration-300 dark:-rotate-90 dark:scale-0"

--- a/src/components/UnifiedSearchBar.tsx
+++ b/src/components/UnifiedSearchBar.tsx
@@ -266,8 +266,9 @@ export const UnifiedSearchBar = forwardRef<
               onBlur={(e) => {
                 setIsFocused(false);
                 const relatedTarget = e.relatedTarget as HTMLElement | null;
-                const isDropdownClick =
-                  relatedTarget?.closest('[data-search-history-dropdown="true"]');
+                const isDropdownClick = relatedTarget?.closest(
+                  '[data-search-history-dropdown="true"]',
+                );
                 if (!isDropdownClick) {
                   setTimeout(() => setShowHistoryDropdown(false), 200);
                 }
@@ -282,6 +283,7 @@ export const UnifiedSearchBar = forwardRef<
             {query && (
               <button
                 aria-label={t('search.clear')}
+                data-testid="search-clear-button"
                 className="p-2 min-h-[36px] min-w-[36px] flex items-center justify-center text-muted-foreground hover:text-foreground flex-shrink-0 rounded-lg hover:bg-secondary transition-colors"
                 onClick={() => {
                   setQuery('');
@@ -310,6 +312,7 @@ export const UnifiedSearchBar = forwardRef<
               variant="accent"
               size="sm"
               className="h-9 sm:h-10 px-3 sm:px-4 rounded-lg gap-1.5 sm:gap-2 font-medium flex-shrink-0"
+              data-testid="search-submit-button"
               aria-label={
                 rateLimitCountdown > 0
                   ? t('search.waitSeconds').replace(

--- a/src/tests/e2e/accessibility.spec.ts
+++ b/src/tests/e2e/accessibility.spec.ts
@@ -16,7 +16,10 @@ test.describe('Accessibility Audits @a11y', () => {
 
     if (criticalOrSerious.length > 0) {
       const summary = criticalOrSerious
-        .map((v) => `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`)
+        .map(
+          (v) =>
+            `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`,
+        )
         .join('\n');
       // eslint-disable-next-line no-console
       console.error('Accessibility violations:\n' + summary);
@@ -25,9 +28,7 @@ test.describe('Accessibility Audits @a11y', () => {
     expect(criticalOrSerious).toHaveLength(0);
   });
 
-  test('card modal has no critical or serious violations', async ({
-    page,
-  }) => {
+  test('card modal has no critical or serious violations', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
     const searchInput = page.locator('#search-input').first();
@@ -44,7 +45,7 @@ test.describe('Accessibility Audits @a11y', () => {
     await responsePromise;
 
     // Open the first card modal
-    const firstCard = page.locator('[data-testid="card-item"], .card-item, [class*="card"]').first();
+    const firstCard = page.getByTestId('search-result-card').first();
     await expect(firstCard).toBeVisible({ timeout: 15_000 });
     await firstCard.click();
 
@@ -62,7 +63,10 @@ test.describe('Accessibility Audits @a11y', () => {
 
     if (criticalOrSerious.length > 0) {
       const summary = criticalOrSerious
-        .map((v) => `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`)
+        .map(
+          (v) =>
+            `[${v.impact}] ${v.id}: ${v.description} (${v.nodes.length} nodes)`,
+        )
         .join('\n');
       // eslint-disable-next-line no-console
       console.error('Modal accessibility violations:\n' + summary);

--- a/src/tests/e2e/search.spec.ts
+++ b/src/tests/e2e/search.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 const SEARCH_INPUT_SELECTOR = '#search-input';
-const CARD_SELECTOR = '[data-testid="card-item"], .card-item, [class*="card"]';
+const CARD_SELECTOR = '[data-testid="search-result-card"]';
 
 test.describe('Search Flow', () => {
   test('page loads and search input is visible', async ({ page }) => {
@@ -39,9 +39,6 @@ test.describe('Search Flow', () => {
     const searchInput = page.locator(SEARCH_INPUT_SELECTOR).first();
     await expect(searchInput).toBeVisible({ timeout: 15_000 });
 
-    // Wait for any warmup/ping calls to finish before attaching listener
-    await page.waitForTimeout(3000);
-
     const semanticSearchCalls: string[] = [];
     page.on('request', (req) => {
       if (req.url().includes('semantic-search')) {
@@ -49,10 +46,10 @@ test.describe('Search Flow', () => {
       }
     });
 
-    await searchInput.fill('');
+    await searchInput.fill('   ');
     await searchInput.press('Enter');
 
-    await page.waitForTimeout(1000);
+    await expect(searchInput).toBeVisible();
     expect(semanticSearchCalls).toHaveLength(0);
   });
 

--- a/src/tests/e2e/user-flows.spec.ts
+++ b/src/tests/e2e/user-flows.spec.ts
@@ -1,8 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 const SEARCH_INPUT_SELECTOR = '#search-input';
-const CARD_SELECTOR =
-  '[data-testid="card-item"], .card-item, [class*="card"]';
+const CARD_SELECTOR = '[data-testid="search-result-card"]';
 
 /* ------------------------------------------------------------------ */
 /*  Example chip & search bar interactions                            */
@@ -52,9 +51,7 @@ test.describe('User Flows', () => {
     await expect(searchInput).toHaveValue('test query');
 
     // The clear (X) button appears when there is text
-    const clearButton = page.locator('button[aria-label]').filter({
-      has: page.locator('svg.lucide-x'),
-    });
+    const clearButton = page.getByTestId('search-clear-button');
     await expect(clearButton).toBeVisible({ timeout: 3_000 });
     await clearButton.click();
 
@@ -67,11 +64,19 @@ test.describe('User Flows', () => {
     await expect(searchInput).toBeVisible({ timeout: 15_000 });
 
     // The search submit button should be present
-    const searchButton = page.locator(
-      'button[aria-label*="search" i], button:has(svg.lucide-search)',
-    ).first();
+    const searchButton = page.getByTestId('search-submit-button');
     await expect(searchButton).toBeVisible();
     await expect(searchButton).toBeEnabled();
+  });
+
+  test('search help trigger opens the help modal', async ({ page }) => {
+    await page.goto('/');
+
+    const helpTrigger = page.getByTestId('search-help-trigger').first();
+    await expect(helpTrigger).toBeVisible({ timeout: 15_000 });
+    await helpTrigger.click();
+
+    await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5_000 });
   });
 
   test('keyboard shortcut / focuses the search input', async ({ page }) => {
@@ -92,17 +97,15 @@ test.describe('User Flows', () => {
     await page.waitForLoadState('domcontentloaded');
 
     // Find the theme toggle button
-    const themeToggle = page.locator('button[aria-label*="theme" i]').first();
+    const themeToggle = page.getByTestId('theme-toggle');
 
     // Skip if not visible (may be hidden in mobile)
     if (await themeToggle.isVisible()) {
       const htmlBefore = await page.locator('html').getAttribute('class');
       await themeToggle.click();
-      await page.waitForTimeout(500);
-      const htmlAfter = await page.locator('html').getAttribute('class');
-
-      // The class should have changed (dark ↔ light)
-      expect(htmlAfter).not.toBe(htmlBefore);
+      await expect
+        .poll(async () => page.locator('html').getAttribute('class'))
+        .not.toBe(htmlBefore);
     }
   });
 


### PR DESCRIPTION
### Motivation
- Stabilize E2E selectors by introducing explicit hooks and avoid brittle CSS/icon based locators.
- Replace ad-hoc `waitForTimeout` sleeps with deterministic waits to reduce flakiness and speed up tests.
- Make primary interactive elements easier to target from Playwright by adding testids.

### Description
- Added `data-testid="search-result-card"` to card renderers in `CardImageItem` and `CardListItem` to unify card selection across views.
- Added `data-testid` attributes for controls used in E2E specs: `search-clear-button`, `search-submit-button`, `theme-toggle`, and `search-help-trigger` in `UnifiedSearchBar`, `ThemeToggle`, and `SearchHelpModal`.
- Updated E2E specs under `src/tests/e2e/` (`search.spec.ts`, `user-flows.spec.ts`, `accessibility.spec.ts`) to use `getByTestId` / testid-based locators and role-based checks instead of `[class*="card"]` and icon-class selectors.
- Removed `page.waitForTimeout` where possible and replaced with deterministic waits such as `waitForResponse`, `expect(...).toBeVisible()`, and `expect.poll(...)`; added an explicit small flow test for opening the search help modal via the new trigger.

### Testing
- Ran `npm run lint` and the lint step completed successfully.
- Ran `npm run typecheck` and `tsc` completed without errors.
- Ran `npm run test` (Vitest): the suite ran and the vast majority of tests passed (`1374 passed | 332 skipped`), but the process exited non-zero due to a pre-existing unhandled `window is not defined` error reported in `src/lib/i18n/__tests__/locale-detection.test.ts`; this failure is unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a53ce49e2c8330a150bca52093f8e7)