### PR TITLE
ci: add PR smoke e2e and a11y gates and document required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,46 @@ jobs:
             fi
           fi
 
-  # ─── E2E tests (nightly + manual + PR opt-in label) ────────────────
+  # ─── PR smoke E2E gate (always-on for PRs) ─────────────────────────
+  e2e-smoke:
+    if: github.event_name == 'pull_request'
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright deps (OS libraries only)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - name: Run PR smoke E2E tests (navigation + search + dialog)
+        run: npx playwright test src/tests/e2e/navigation.spec.ts src/tests/e2e/search.spec.ts src/tests/e2e/dialog-keyboard-accessibility.spec.ts --project=chromium
+      - name: Upload smoke Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-smoke
+          path: playwright-report
+          retention-days: 14
+
+  # ─── Full E2E tests (push + nightly + manual + PR opt-in label) ───
   e2e:
     if: |
+      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_e2e) ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:e2e'))
@@ -202,9 +239,46 @@ jobs:
           path: test-results
           retention-days: 7
 
-  # ─── Accessibility tests (nightly + manual + PR opt-in label) ──────
+  # ─── PR smoke accessibility gate (always-on for PRs) ────────────────
+  a11y-smoke:
+    if: github.event_name == 'pull_request'
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: nm-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+      - name: Install Playwright deps (OS libraries only)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+      - name: Run PR smoke accessibility suite (axe)
+        run: npx playwright test src/tests/e2e/accessibility.spec.ts --project=chromium
+      - name: Upload smoke a11y report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-report-smoke
+          path: playwright-report
+          retention-days: 14
+
+  # ─── Full accessibility tests (push + nightly + manual + PR label) ─
   a11y:
     if: |
+      github.event_name == 'push' ||
       github.event_name == 'schedule' ||
       (github.event_name == 'workflow_dispatch' && inputs.run_a11y) ||
       (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:a11y'))

--- a/TESTING.md
+++ b/TESTING.md
@@ -28,8 +28,10 @@ The GitHub Actions workflow (`.github/workflows/ci.yml`) runs parallel jobs for 
       ├──► test          (vitest + coverage thresholds, every push/PR)
       ├──► build         (vite build, every push/PR)
        └──► bundle-size   (gzip check ≤500KB JS, every push/PR)
-       ├──► e2e            (Playwright search flow, every push/PR + nightly)
-       ├──► a11y           (axe accessibility audits, every push/PR + nightly)
+       ├──► e2e-smoke      (PR-required smoke suite: navigation + search + dialog)
+       ├──► a11y-smoke     (PR-required axe smoke suite)
+       ├──► e2e            (full Playwright matrix on push/nightly/manual + PR opt-in label)
+       ├──► a11y           (full axe matrix on push/nightly/manual + PR opt-in label)
 
 On-demand jobs:
    ├──► api-security     (edge function HTTP tests, workflow_dispatch only)
@@ -38,13 +40,27 @@ On-demand jobs:
 
 ### Triggers
 
-| Trigger | Jobs |
-|---------|------|
-| `push` to `main` | lint, typecheck, test, build, bundle-size, e2e, a11y |
-| Pull request | lint, typecheck, test, build, bundle-size, e2e, a11y |
-| Nightly (`0 3 * * *`) | e2e, a11y |
-| Weekly (`0 6 * * 1`) | live-scryfall-validation |
-| `workflow_dispatch` | All jobs available on-demand |
+| Trigger               | Jobs                                                                                                             |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `push` to `main`      | lint, typecheck, test, build, bundle-size, e2e, a11y                                                             |
+| Pull request          | lint, typecheck, test, build, bundle-size, e2e-smoke, a11y-smoke (full e2e/a11y via `ci:e2e` / `ci:a11y` labels) |
+| Nightly (`0 3 * * *`) | e2e, a11y                                                                                                        |
+| Weekly (`0 6 * * 1`)  | live-scryfall-validation                                                                                         |
+| `workflow_dispatch`   | All jobs available on-demand                                                                                     |
+
+### Required status checks for branch protection
+
+Configure branch protection for `main` to require these checks on pull requests:
+
+- `lint`
+- `typecheck`
+- `test`
+- `build`
+- `bundle-size`
+- `e2e-smoke`
+- `a11y-smoke`
+
+This keeps a lightweight always-on gate (critical navigation/search/dialog plus one axe suite) while preserving broader full-suite coverage in push/nightly/manual runs.
 
 ---
 
@@ -83,18 +99,18 @@ npm run test -- translation-golden
 
 Located in `src/lib/security/`. Comprehensive coverage:
 
-| Category | File |
-|----------|------|
-| Input Sanitization | `input-sanitization.test.ts` |
-| Injection Attacks | `injection.test.ts` |
-| Rate Limiting | `rate-limiting.test.ts` |
-| Authentication | `authentication.test.ts` |
-| CORS Protection | `cors-bypass.test.ts` |
+| Category            | File                          |
+| ------------------- | ----------------------------- |
+| Input Sanitization  | `input-sanitization.test.ts`  |
+| Injection Attacks   | `injection.test.ts`           |
+| Rate Limiting       | `rate-limiting.test.ts`       |
+| Authentication      | `authentication.test.ts`      |
+| CORS Protection     | `cors-bypass.test.ts`         |
 | Prototype Pollution | `prototype-pollution.test.ts` |
-| ReDoS Prevention | `redos.test.ts` |
-| Timing Attacks | `timing-attacks.test.ts` |
-| Error Leakage | `error-leakage.test.ts` |
-| Config Sync | `config-sync.test.ts` |
+| ReDoS Prevention    | `redos.test.ts`               |
+| Timing Attacks      | `timing-attacks.test.ts`      |
+| Error Leakage       | `error-leakage.test.ts`       |
+| Config Sync         | `config-sync.test.ts`         |
 
 ```bash
 npm run test -- src/lib/security
@@ -118,6 +134,7 @@ npx playwright test
 ```
 
 **Tests:**
+
 1. Page loads and search input is visible
 2. Typing a query and pressing Enter shows card results
 3. Submitting empty query shows inline error without network call
@@ -166,12 +183,12 @@ npm run test -- src/lib/regression
 
 Coverage is enforced by Vitest on every test run. The build **fails** if thresholds are not met.
 
-| Metric | Threshold |
-|--------|-----------|
-| Lines | 85% |
-| Functions | 85% |
-| Branches | 80% |
-| Statements | 85% |
+| Metric     | Threshold |
+| ---------- | --------- |
+| Lines      | 85%       |
+| Functions  | 85%       |
+| Branches   | 80%       |
+| Statements | 85%       |
 
 **Scope:** `src/lib/**` (excluding `src/lib/logger.ts`)
 
@@ -193,12 +210,12 @@ CI fails if total gzipped JS assets in `dist/assets/` exceed **500KB**. The bund
 
 ## Configuration Files
 
-| File | Purpose |
-|------|---------|
-| `vite.config.ts` | Vitest config (test section), coverage thresholds |
-| `playwright.config.ts` | Playwright config, targets `localhost:8080` |
-| `.github/workflows/ci.yml` | Full CI pipeline definition |
-| `src/test/setup.ts` | Vitest setup (jest-dom, matchMedia polyfill) |
+| File                       | Purpose                                           |
+| -------------------------- | ------------------------------------------------- |
+| `vite.config.ts`           | Vitest config (test section), coverage thresholds |
+| `playwright.config.ts`     | Playwright config, targets `localhost:8080`       |
+| `.github/workflows/ci.yml` | Full CI pipeline definition                       |
+| `src/test/setup.ts`        | Vitest setup (jest-dom, matchMedia polyfill)      |
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -160,4 +160,6 @@ deno test --allow-env --allow-net supabase/functions/semantic-search/benchmark.t
 
 ## CI Integration
 
-All tests run automatically on pull requests via GitHub Actions (`.github/workflows/ci.yml`). Security tests are included in the regression suite exported from `src/lib/regression/index.ts`. Live Scryfall validation runs in a separate job on a weekly schedule to avoid flaky builds from external API dependencies.
+All tests run automatically on pull requests via GitHub Actions (`.github/workflows/ci.yml`). Pull requests always run lightweight `e2e-smoke` and `a11y-smoke` jobs (critical navigation/search/dialog + one axe suite), while full `e2e` and `a11y` coverage remains on push/nightly/manual runs and can be opted into on PRs with `ci:e2e` / `ci:a11y` labels. Security tests are included in the regression suite exported from `src/lib/regression/index.ts`. Live Scryfall validation runs in a separate job on a weekly schedule to avoid flaky builds from external API dependencies.
+
+For branch protection, require: `lint`, `typecheck`, `test`, `build`, `bundle-size`, `e2e-smoke`, and `a11y-smoke`.


### PR DESCRIPTION
### Motivation
- Reduce PR feedback time by running a lightweight always-on Playwright smoke suite and an axe audit on every pull request while keeping the full/nightly matrix for broader coverage.
- Ensure branch protection can enforce a minimal, meaningful gate (critical navigation/search/dialog + one axe suite) before merges.

### Description
- Added `e2e-smoke` CI job that runs on every `pull_request` and executes targeted Playwright tests for navigation, search, and dialog keyboard flows (`src/tests/e2e/navigation.spec.ts`, `src/tests/e2e/search.spec.ts`, `src/tests/e2e/dialog-keyboard-accessibility.spec.ts`).
- Added `a11y-smoke` CI job that runs on every `pull_request` and runs the axe accessibility smoke suite (`src/tests/e2e/accessibility.spec.ts`).
- Kept the existing full `e2e` and `a11y` jobs for `push`, `schedule`, `workflow_dispatch`, and PR opt-in via labels `ci:e2e` / `ci:a11y` by adjusting their trigger conditions.
- Updated `TESTING.md` and `docs/testing.md` to reflect the new trigger model and added a short section listing required status checks for branch protection including `e2e-smoke` and `a11y-smoke`.

### Testing
- Ran `npx prettier --check .github/workflows/ci.yml TESTING.md docs/testing.md` which reported style issues and then ran `npx prettier --write` to format the changed files, and re-checked successfully.
- Verified the CI YAML diff and updated documentation were committed (git commit succeeded) and no other automated test suites were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a541dce8708330a4b18561b2387695)