### PR TITLE
test(e2e): add deckbuilder primary accessibility audit coverage

### DIFF
--- a/src/tests/e2e/accessibility.spec.ts
+++ b/src/tests/e2e/accessibility.spec.ts
@@ -48,4 +48,17 @@ test.describe('Accessibility Audits @a11y', () => {
 
     expect(blockingViolations).toHaveLength(0);
   });
+
+  test('deckbuilder primary view has no critical or serious violations', async ({
+    page,
+  }, testInfo) => {
+    await page.goto('/deckbuilder');
+    await page.waitForLoadState('networkidle');
+
+    const { blockingViolations } = await runAxeAudit(page, testInfo, {
+      context: 'deckbuilder-primary',
+    });
+
+    expect(blockingViolations).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
### Motivation
- Add automated a11y coverage for the `/deckbuilder` primary view to ensure no critical/serious accessibility regressions are introduced by running the same Axe-based audit used elsewhere.

### Description
- Added a new E2E test in `src/tests/e2e/accessibility.spec.ts` that navigates to `/deckbuilder`, waits for `networkidle`, runs `runAxeAudit(page, testInfo, { context: 'deckbuilder-primary' })`, and asserts `blockingViolations` has length `0`, while continuing to reuse the existing `runAxeAudit` helper to preserve moderate-violation attachment behavior.

### Testing
- Executed `npx playwright test src/tests/e2e/accessibility.spec.ts --project=chromium --grep "deckbuilder primary view"`, which failed in this environment because Playwright Chromium is not installed and requires `npx playwright install` to run the browser-based tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a54334066c8330900645610d37eed8)