### PR TITLE
test(e2e): add deterministic Playwright specs for auth, deckbuilder, report-issue, and admin

### DIFF
--- a/src/tests/e2e/admin.spec.ts
+++ b/src/tests/e2e/admin.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from '@playwright/test';
+
+const analyticsFixture = {
+  summary: {
+    totalSearches: 42,
+    avgConfidence: 0.91,
+    avgResponseTime: 321,
+    fallbackRate: 4,
+    days: 7,
+  },
+  responsePercentiles: { p50: 240, p95: 720, p99: 1300 },
+  sourceBreakdown: { deterministic: 30, ai: 12 },
+  popularQueries: [],
+  dailyVolume: { '2026-01-01': 10, '2026-01-02': 32 },
+  deterministicCoverage: { '2026-01-01': 80, '2026-01-02': 76 },
+};
+
+test.describe('Admin analytics access control', () => {
+  test('unauthenticated user is redirected away from admin page', async ({
+    page,
+  }) => {
+    await page.goto('/admin/analytics');
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('seeded admin user can load analytics view', async ({ page }) => {
+    const userId = 'admin-user-1';
+
+    await page.route('**/auth/v1/token?grant_type=password', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'admin-access-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'admin-refresh-token',
+          user: { id: userId, email: 'admin@example.com' },
+        }),
+      });
+    });
+
+    await page.route('**/rest/v1/profiles**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route('**/rest/v1/user_roles**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([{ role: 'admin' }]),
+      });
+    });
+
+    await page.route('**/rest/v1/search_feedback**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route('**/rest/v1/translation_rules**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route('**/functions/v1/admin-analytics**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(analyticsFixture),
+      });
+    });
+
+    await page.goto('/');
+    await page
+      .getByRole('button', { name: /sign in/i })
+      .first()
+      .click();
+
+    const authDialog = page.getByRole('dialog').first();
+    await authDialog.getByLabel('Email').fill('admin@example.com');
+    await authDialog.getByLabel('Password').fill('password123');
+    await authDialog.getByRole('button', { name: /^sign in$/i }).click();
+
+    await page.goto('/admin/analytics');
+
+    await expect(
+      page.getByRole('heading', { name: /search analytics/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/total searches/i)).toBeVisible();
+    await expect(page.getByText('42')).toBeVisible();
+  });
+});

--- a/src/tests/e2e/auth.spec.ts
+++ b/src/tests/e2e/auth.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+function mockAuthEndpoints() {
+  return async ({ page }: { page: Page }) => {
+    await page.route('**/auth/v1/signup', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user: {
+            id: 'user-signup-1',
+            email: 'new-user@example.com',
+            identities: [{ id: 'identity-1' }],
+          },
+          session: null,
+        }),
+      });
+    });
+
+    await page.route('**/auth/v1/token?grant_type=password', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'access-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'refresh-token',
+          user: { id: 'user-signin-1', email: 'existing@example.com' },
+        }),
+      });
+    });
+
+    await page.route('**/auth/v1/recover', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
+  };
+}
+
+test.describe('Auth modal flows', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockAuthEndpoints()({ page });
+  });
+
+  test('signup happy path (deterministic mocked equivalent)', async ({
+    page,
+  }) => {
+    await page.goto('/');
+
+    await page
+      .getByRole('button', { name: /sign in/i })
+      .first()
+      .click();
+    const dialog = page.getByRole('dialog').first();
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByRole('button', { name: /^sign up$/i }).click();
+    await dialog.getByLabel('Email').fill('new-user@example.com');
+    await dialog.getByLabel('Password').fill('password123');
+    await dialog.getByRole('button', { name: /create account/i }).click();
+
+    await expect(
+      dialog.getByText(/check your email to confirm your account/i),
+    ).toBeVisible();
+  });
+
+  test('signin happy path', async ({ page }) => {
+    await page.goto('/');
+
+    await page
+      .getByRole('button', { name: /sign in/i })
+      .first()
+      .click();
+    const dialog = page.getByRole('dialog').first();
+
+    await dialog.getByLabel('Email').fill('existing@example.com');
+    await dialog.getByLabel('Password').fill('password123');
+    await dialog.getByRole('button', { name: /^sign in$/i }).click();
+
+    await expect(dialog).toBeHidden();
+  });
+
+  test('password reset request flow', async ({ page }) => {
+    await page.goto('/');
+
+    await page
+      .getByRole('button', { name: /sign in/i })
+      .first()
+      .click();
+    const dialog = page.getByRole('dialog').first();
+
+    await dialog.getByRole('button', { name: /forgot password\?/i }).click();
+    await dialog.getByLabel('Email').fill('existing@example.com');
+    await dialog.getByRole('button', { name: /send reset link/i }).click();
+
+    await expect(
+      dialog.getByText(/check your email for a password reset link/i),
+    ).toBeVisible();
+  });
+});

--- a/src/tests/e2e/deckbuilder-core.spec.ts
+++ b/src/tests/e2e/deckbuilder-core.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test } from '@playwright/test';
+
+type DeckRecord = {
+  id: string;
+  user_id: string;
+  name: string;
+  format: string;
+  commander_name: string | null;
+  companion_name: string | null;
+  color_identity: string[];
+  description: string | null;
+  is_public: boolean;
+  card_count: number;
+  created_at: string;
+  updated_at: string;
+};
+
+test.describe('Deckbuilder core flows', () => {
+  test('create/import/edit/save with deterministic fixtures', async ({
+    page,
+  }) => {
+    const now = new Date().toISOString();
+    const userId = 'user-1';
+    const decks: DeckRecord[] = [];
+
+    await page.route('**/auth/v1/token?grant_type=password', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'access-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          refresh_token: 'refresh-token',
+          user: { id: userId, email: 'deck-user@example.com' },
+        }),
+      });
+    });
+
+    await page.route('**/rest/v1/profiles**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route('**/rest/v1/decks**', async (route) => {
+      const request = route.request();
+      const method = request.method();
+
+      if (method === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(decks),
+        });
+        return;
+      }
+
+      if (method === 'POST') {
+        const payload = request.postDataJSON() as {
+          name: string;
+          format: string;
+          user_id: string;
+        };
+        const newDeck: DeckRecord = {
+          id: `deck-${decks.length + 1}`,
+          user_id: payload.user_id,
+          name: payload.name,
+          format: payload.format,
+          commander_name: null,
+          companion_name: null,
+          color_identity: [],
+          description: null,
+          is_public: false,
+          card_count: 0,
+          created_at: now,
+          updated_at: new Date().toISOString(),
+        };
+        decks.unshift(newDeck);
+        await route.fulfill({
+          status: 201,
+          contentType: 'application/json',
+          body: JSON.stringify([newDeck]),
+        });
+        return;
+      }
+
+      if (method === 'PATCH') {
+        const payload = request.postDataJSON() as Partial<DeckRecord>;
+        const deckIdMatch = request.url().match(/id=eq\.([^&]+)/);
+        const deckId = deckIdMatch?.[1] ?? '';
+        const idx = decks.findIndex(
+          (deck) => deck.id === decodeURIComponent(deckId),
+        );
+        if (idx >= 0) {
+          decks[idx] = {
+            ...decks[idx],
+            ...payload,
+            updated_at: new Date().toISOString(),
+          };
+        }
+        await route.fulfill({ status: 204, body: '' });
+        return;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.route('**/rest/v1/deck_cards**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([]),
+      });
+    });
+
+    await page.goto('/deckbuilder');
+
+    await page.getByRole('button', { name: /sign in to get started/i }).click();
+    const authDialog = page.getByRole('dialog').first();
+    await authDialog.getByLabel('Email').fill('deck-user@example.com');
+    await authDialog.getByLabel('Password').fill('password123');
+    await authDialog.getByRole('button', { name: /^sign in$/i }).click();
+
+    const createDeckButton = page
+      .getByRole('button', { name: /new deck|create deck/i })
+      .first();
+    await expect(createDeckButton).toBeVisible();
+    await createDeckButton.click();
+    await page.waitForURL(/\/deckbuilder\/deck-1/);
+
+    await page.getByRole('link', { name: /back/i }).click();
+    await page.waitForURL('**/deckbuilder');
+
+    await page
+      .getByRole('button', { name: /import/i })
+      .first()
+      .click();
+    const importDialog = page.getByRole('dialog').first();
+    await importDialog.locator('button').nth(1).click();
+    await importDialog.getByRole('textbox').fill('1 Sol Ring\n1 Arcane Signet');
+    await importDialog
+      .getByRole('button', { name: /import/i })
+      .last()
+      .click();
+
+    await page.waitForURL(/\/deckbuilder\/deck-2/);
+
+    const deckTitle = page.getByRole('heading', { level: 2 });
+    await deckTitle.click();
+    await page.getByRole('textbox').first().fill('Edited Deterministic Deck');
+    await page.keyboard.press('Enter');
+
+    await page.getByRole('button', { name: /add notes|edit notes/i }).click();
+    const notesInput = page.getByPlaceholder(/describe|notes/i);
+    await notesInput.fill('Persisted deck notes from e2e');
+    await notesInput.blur();
+
+    await page.reload();
+    await expect(
+      page.getByRole('heading', {
+        level: 2,
+        name: 'Edited Deterministic Deck',
+      }),
+    ).toBeVisible();
+  });
+});

--- a/src/tests/e2e/report-issue.spec.ts
+++ b/src/tests/e2e/report-issue.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Report issue dialog', () => {
+  test('validation errors and successful submit confirmation state', async ({
+    page,
+  }) => {
+    await page.route('**/rest/v1/search_feedback**', async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
+
+    await page.route('**/rest/v1/analytics_events**', async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({}),
+      });
+    });
+
+    await page.route('**/functions/v1/process-feedback', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await page.goto('/');
+
+    const searchInput = page.locator('#search-input').first();
+    await searchInput.fill('counterspell');
+    await searchInput.press('Enter');
+
+    const reportTrigger = page
+      .getByRole('button', { name: /report issue/i })
+      .first();
+    await expect(reportTrigger).toBeVisible({ timeout: 15_000 });
+    await reportTrigger.click();
+
+    const reportDialog = page.getByRole('dialog').first();
+    const issueField = reportDialog.getByLabel(/what went wrong\?/i);
+
+    await issueField.fill('bad');
+    await reportDialog.getByRole('button', { name: /submit report/i }).click();
+    await expect(
+      reportDialog.getByText(/at least 10 characters/i),
+    ).toBeVisible();
+
+    await issueField.fill(
+      'Search translation dropped key combo card from results.',
+    );
+    await reportDialog.getByRole('button', { name: /submit report/i }).click();
+
+    await expect(reportDialog).toBeHidden();
+    await expect(page.getByText(/issue reported/i)).toBeVisible();
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide deterministic end-to-end coverage for critical user flows (auth, deckbuilder core, reporting feedback, and admin analytics) to reduce CI flakiness.
- Ensure the deckbuilder create/import/edit/save surface is validated in isolation using in-test fixtures rather than relying on brittle external state.
- Surface validation and access-control behavior for feedback and admin pages so regressions are caught early.

### Description
- Add four new Playwright spec files under `src/tests/e2e/`: `auth.spec.ts`, `deckbuilder-core.spec.ts`, `report-issue.spec.ts`, and `admin.spec.ts` that exercise the flows requested.
- Use deterministic request fixtures via `page.route` to mock Supabase auth endpoints, REST endpoints (`/rest/v1/decks`, `/rest/v1/deck_cards`, `/rest/v1/user_roles`, `/rest/v1/search_feedback`, etc.) and edge function responses to keep tests stable in CI.
- `auth.spec.ts` covers signup, signin, and password reset request flows with mocked Supabase auth endpoints; `deckbuilder-core.spec.ts` covers create deck, import (paste flow), edit metadata, and persistence check after reload using an in-test deck store; `report-issue.spec.ts` asserts the existing validation message (`at least 10 characters`) and verifies successful submit state; `admin.spec.ts` validates unauthenticated redirect and a seeded admin path that loads analytics from a fixture.
- Tests are written in TypeScript and avoid introducing `any`, and they reuse existing UI labels and assertions already present in the app codebase.

### Testing
- Ran ESLint on the new specs with `npx eslint src/tests/e2e/*.ts` and the lint pass completed successfully.
- Ran TypeScript checks with `npm run typecheck` which completed successfully with no type errors.
- Attempted to run `npx playwright test` for the auth spec, but the run failed to launch browsers in this environment because Playwright browser binaries were not installed (the environment needs `npx playwright install` to run the browser-based tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a543313bcc83308573134fc211b5d3)