### PR TITLE
Fix SearchFilters missing hook import and lint error

### DIFF
--- a/src/components/SearchFilters.tsx
+++ b/src/components/SearchFilters.tsx
@@ -25,6 +25,12 @@ import { cn } from '@/lib/core/utils';
 import { Filter, ArrowUpDown, X, ChevronDown, Package } from 'lucide-react';
 import { useTranslation } from '@/lib/i18n';
 import { useAuth } from '@/hooks/useAuth';
+import { useSearchFilterState } from '@/components/SearchFilters/useSearchFilterState';
+import {
+  applyCardFilters,
+  countActiveFilters,
+  hasActiveFilters as getHasActiveFilters,
+} from '@/components/SearchFilters/filtering';
 
 // Color definitions with mana symbols
 const COLORS = [
@@ -82,15 +88,6 @@ const SORT_OPTIONS = [
   { value: 'edhrec-asc', labelKey: 'filters.sortEdhrecAsc' },
   { value: 'edhrec-desc', labelKey: 'filters.sortEdhrecDesc' },
 ] as const;
-
-const RARITY_ORDER = {
-  common: 0,
-  uncommon: 1,
-  rare: 2,
-  mythic: 3,
-  special: 4,
-  bonus: 5,
-};
 
 interface SearchFiltersProps {
   cards: ScryfallCard[];


### PR DESCRIPTION
### Motivation

- Restore runtime behavior and lint compliance for the `SearchFilters` component by wiring up the extracted filter state hook and removing an unused constant that triggered ESLint.

### Description

- Import the `useSearchFilterState` hook from `src/components/SearchFilters/useSearchFilterState` and use it for filter state management in `SearchFilters.tsx`.
- Import filter helpers (`applyCardFilters`, `countActiveFilters`, and `hasActiveFilters` aliased to `getHasActiveFilters`) from `src/components/SearchFilters/filtering` and replace local references so filtering and counting logic are centralized.
- Remove the unused `RARITY_ORDER` constant from `SearchFilters.tsx` to satisfy `@typescript-eslint/no-unused-vars` and keep the file lint-clean.
- Change only imports/usage in `src/components/SearchFilters.tsx` and do not alter component behavior or types.

### Testing

- Ran `npm run lint` and it completed successfully (no lint errors). ✅
- Ran unit tests for the component with `npm run test -- src/components/__tests__/SearchFilters.test.tsx` and all tests passed (18/18). ✅
- Ran Playwright accessibility suite with `npx playwright test src/tests/e2e/accessibility.spec.ts --project=chromium` which failed in this environment because Playwright browsers are not installed (error: missing Chromium executable; requires `npx playwright install`). ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a545d9e8788330abdea512864ab17f)