### PR TITLE
Fix flaky integration text assertions and restrict Playwright to E2E specs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './src/tests/e2e',
+  testMatch: '**/*.spec.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/src/pages/__tests__/Index.integration.test.tsx
+++ b/src/pages/__tests__/Index.integration.test.tsx
@@ -111,9 +111,21 @@ vi.mock('@/components/AuthProvider', () => ({
 // ── Helpers ────────────────────────────────────────────────
 
 const MOCK_CARDS: ScryfallCard[] = [
-  createMockCard({ id: 'card-1', name: 'Dockside Extortionist', type_line: 'Creature — Goblin Pirate' }),
-  createMockCard({ id: 'card-2', name: 'Smothering Tithe', type_line: 'Enchantment' }),
-  createMockCard({ id: 'card-3', name: 'Treasure Vault', type_line: 'Artifact Land' }),
+  createMockCard({
+    id: 'card-1',
+    name: 'Dockside Extortionist',
+    type_line: 'Creature — Goblin Pirate',
+  }),
+  createMockCard({
+    id: 'card-2',
+    name: 'Smothering Tithe',
+    type_line: 'Enchantment',
+  }),
+  createMockCard({
+    id: 'card-3',
+    name: 'Treasure Vault',
+    type_line: 'Artifact Land',
+  }),
 ];
 
 function renderIndex(initialRoute = '/') {
@@ -181,9 +193,7 @@ describe('Index page integration', () => {
 
   it('displays skeleton loaders while searching', async () => {
     // Make translation hang to keep loading state
-    mockTranslateQueryWithDedup.mockImplementation(
-      () => new Promise(() => {}),
-    );
+    mockTranslateQueryWithDedup.mockImplementation(() => new Promise(() => {}));
 
     renderIndex();
 
@@ -212,11 +222,19 @@ describe('Index page integration', () => {
     fireEvent.keyDown(input, { key: 'Enter' });
 
     // Wait for cards to appear
-    await waitFor(() => {
-      expect(screen.getByText('Dockside Extortionist')).toBeInTheDocument();
-    });
-    expect(screen.getByText('Smothering Tithe')).toBeInTheDocument();
-    expect(screen.getByText('Treasure Vault')).toBeInTheDocument();
+    const expectedCardNames = [
+      'Dockside Extortionist',
+      'Smothering Tithe',
+      'Treasure Vault',
+    ];
+
+    for (const cardName of expectedCardNames) {
+      await waitFor(() => {
+        expect(
+          screen.getByText((_, element) => element?.textContent === cardName),
+        ).toBeInTheDocument();
+      });
+    }
   });
 
   it('shows empty state when no results are returned', async () => {
@@ -247,7 +265,9 @@ describe('Index page integration', () => {
     renderIndex();
 
     await waitFor(() => {
-      expect(screen.getByText('creatures that make treasure tokens')).toBeInTheDocument();
+      expect(
+        screen.getByText('creatures that make treasure tokens'),
+      ).toBeInTheDocument();
     });
     const exampleBtn = screen.getByText('creatures that make treasure tokens');
     fireEvent.click(exampleBtn);


### PR DESCRIPTION
### Motivation
- Stabilize a brittle integration assertion that failed when card name text was split across nested DOM nodes. 
- Prevent Playwright from discovering Vitest `.test.ts` files in the E2E directory which caused matcher conflicts (`Symbol($$jest-matchers-object)`) in CI.

### Description
- Replace direct `getByText('Dockside Extortionist')` assertions with a loop over expected card names and a text-matcher callback that checks `element?.textContent === cardName` wrapped in `waitFor` in `src/pages/__tests__/Index.integration.test.tsx`.
- Add `testMatch: '**/*.spec.ts'` to `playwright.config.ts` so Playwright only runs `*.spec.ts` E2E files and skips Vitest `.test.ts` files.
- Make small test formatting tweaks to keep assertions consistent and resilient.

### Testing
- Ran the integration unit tests with `npm run test -- src/pages/__tests__/Index.integration.test.tsx` which passed successfully.  
- Attempted `npx playwright test --project=chromium` which failed in this environment due to missing Playwright browser binaries (error: "Executable doesn't exist ... headless_shell").  
- Attempted `npx playwright test --grep @a11y` which also failed in this environment for the same Playwright browser binary reason.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a54701ac988330beaeaabbb237a709)