### PR TITLE
test: stabilize card modal accessibility audit with mocked Scryfall search

### DIFF
--- a/src/tests/e2e/accessibility.spec.ts
+++ b/src/tests/e2e/accessibility.spec.ts
@@ -4,6 +4,105 @@ import { runAxeAudit } from '@/tests/e2e/axe-helpers';
 const SEARCH_INPUT_SELECTOR = '#search-input';
 const SEARCH_RESULT_CARD_SELECTOR = '[data-testid="search-result-card"]';
 
+const MOCK_SCRYFALL_SEARCH_RESPONSE = {
+  object: 'list',
+  total_cards: 1,
+  has_more: false,
+  data: [
+    {
+      object: 'card',
+      id: '00000000-0000-0000-0000-000000000001',
+      oracle_id: '00000000-0000-0000-0000-000000000002',
+      name: 'Lightning Bolt',
+      lang: 'en',
+      released_at: '1993-08-05',
+      uri: 'https://api.scryfall.com/cards/00000000-0000-0000-0000-000000000001',
+      scryfall_uri: 'https://scryfall.com/card/lea/161/lightning-bolt',
+      layout: 'normal',
+      image_uris: {
+        small:
+          'https://cards.scryfall.io/small/front/e/2/e2c2d2f9-0f3f-4f84-97fb-ccfbb2cb5bd8.jpg',
+        normal:
+          'https://cards.scryfall.io/normal/front/e/2/e2c2d2f9-0f3f-4f84-97fb-ccfbb2cb5bd8.jpg',
+        large:
+          'https://cards.scryfall.io/large/front/e/2/e2c2d2f9-0f3f-4f84-97fb-ccfbb2cb5bd8.jpg',
+      },
+      mana_cost: '{R}',
+      cmc: 1,
+      type_line: 'Instant',
+      oracle_text: 'Lightning Bolt deals 3 damage to any target.',
+      colors: ['R'],
+      color_identity: ['R'],
+      keywords: [],
+      legalities: {
+        standard: 'not_legal',
+        future: 'not_legal',
+        historic: 'legal',
+        timeless: 'legal',
+        gladiator: 'legal',
+        pioneer: 'legal',
+        explorer: 'legal',
+        modern: 'legal',
+        legacy: 'legal',
+        pauper: 'legal',
+        vintage: 'legal',
+        penny: 'legal',
+        commander: 'legal',
+        oathbreaker: 'legal',
+        brawl: 'not_legal',
+        standardbrawl: 'not_legal',
+        alchemy: 'not_legal',
+        paupercommander: 'legal',
+        duel: 'legal',
+        oldschool: 'not_legal',
+        premodern: 'legal',
+        predh: 'legal',
+      },
+      games: ['paper', 'mtgo', 'arena'],
+      reserved: false,
+      foil: true,
+      nonfoil: true,
+      finishes: ['nonfoil', 'foil'],
+      oversized: false,
+      promo: false,
+      reprint: true,
+      variation: false,
+      set_id: '00000000-0000-0000-0000-000000000003',
+      set: 'lea',
+      set_name: 'Limited Edition Alpha',
+      set_type: 'core',
+      set_uri: 'https://api.scryfall.com/sets/lea',
+      set_search_uri:
+        'https://api.scryfall.com/cards/search?order=set&q=e%3Alea&unique=prints',
+      scryfall_set_uri: 'https://scryfall.com/sets/lea',
+      rulings_uri:
+        'https://api.scryfall.com/cards/00000000-0000-0000-0000-000000000001/rulings',
+      prints_search_uri:
+        'https://api.scryfall.com/cards/search?order=released&q=oracleid%3A00000000-0000-0000-0000-000000000002&unique=prints',
+      collector_number: '161',
+      digital: false,
+      rarity: 'common',
+      card_back_id: '00000000-0000-0000-0000-000000000004',
+      artist: 'Christopher Rush',
+      border_color: 'black',
+      frame: '1993',
+      full_art: false,
+      textless: false,
+      booster: true,
+      story_spotlight: false,
+      edhrec_rank: 1,
+      prices: {
+        usd: '1.00',
+        usd_foil: '10.00',
+        usd_etched: null,
+        eur: '0.80',
+        eur_foil: '8.00',
+        tix: '0.10',
+      },
+    },
+  ],
+};
+
 async function searchForCard(
   page: Parameters<typeof test>[0]['page'],
   query: string,
@@ -40,6 +139,14 @@ test.describe('Accessibility Audits @a11y', () => {
   test('card modal has no critical or serious violations', async ({
     page,
   }, testInfo) => {
+    await page.route('**/api.scryfall.com/cards/search**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_SCRYFALL_SEARCH_RESPONSE),
+      });
+    });
+
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
     await searchForCard(page, 'lightning bolt');


### PR DESCRIPTION
### Motivation
- Make the Playwright accessibility test for the card modal deterministic by removing reliance on live Scryfall search responses which caused flaky failures when no results were returned at runtime.

### Description
- Add a deterministic `MOCK_SCRYFALL_SEARCH_RESPONSE` and intercept `**/api.scryfall.com/cards/search**` to fulfill with the mock in `src/tests/e2e/accessibility.spec.ts`, so the `card modal has no critical or serious violations` flow always has a predictable first result.

### Testing
- Ran `bun run lint` which completed successfully.
- Ran `bun run test` which executed the test suite (most tests passed), but the run exited non-zero due to an existing unrelated runtime error (`ReferenceError: window is not defined`) in `src/lib/i18n/__tests__/locale-detection.test.ts` in this environment. 
- Attempting `bun run playwright test src/tests/e2e/accessibility.spec.ts --project=chromium --grep "card modal"` cannot be completed here because Playwright browser binaries are not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a548972a608330adacb97724fbd313)