### PR TITLE
Add GitHub Actions to post PR approvals, merges and CI status to Discord

### DIFF
--- a/.github/workflows/discord-ci-status.yml
+++ b/.github/workflows/discord-ci-status.yml
@@ -1,0 +1,38 @@
+name: Discord - CI Status
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+
+jobs:
+  notify-discord:
+    if: github.event.workflow_run.head_branch == github.event.repository.default_branch && (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate webhook secret
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "Missing required secret: DISCORD_WEBHOOK_URL"
+            exit 1
+          fi
+
+      - name: Post CI status to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          REPOSITORY: ${{ github.repository }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          set -euo pipefail
+
+          MESSAGE=$(python -c "import json, os; status=os.environ['CONCLUSION']; emoji='✅' if status == 'success' else '❌'; label='Passed' if status == 'success' else 'Failed'; short_sha=os.environ['COMMIT_SHA'][:7]; content=(f\"{emoji} **CI {label}** in `{os.environ['REPOSITORY']}`\\n\" f\"**Workflow:** {os.environ['WORKFLOW_NAME']}\\n\" f\"**Branch:** `{os.environ['BRANCH']}`\\n\" f\"**Commit:** `{short_sha}`\\n\" f\"{os.environ['RUN_URL']}\"); print(json.dumps({'content': content}))")
+
+          curl -fsS -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "$MESSAGE"

--- a/.github/workflows/discord-pr-approvals.yml
+++ b/.github/workflows/discord-pr-approvals.yml
@@ -1,0 +1,39 @@
+name: Discord - PR Approvals
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify-discord:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate webhook secret
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "Missing required secret: DISCORD_WEBHOOK_URL"
+            exit 1
+          fi
+
+      - name: Post approval message to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          APPROVER: ${{ github.event.review.user.login }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+
+          MESSAGE=$(python -c "import json, os; content=(f\"✅ **PR Approved** in `{os.environ['REPOSITORY']}`\\n\" f\"**#{os.environ['PR_NUMBER']}:** {os.environ['PR_TITLE']}\\n\" f\"**Approver:** {os.environ['APPROVER']} • **Author:** {os.environ['AUTHOR']}\\n\" f\"**Branch:** `{os.environ['HEAD_REF']}` → `{os.environ['BASE_REF']}`\\n\" f\"{os.environ['PR_URL']}\"); print(json.dumps({'content': content}))")
+
+          curl -fsS -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "$MESSAGE"

--- a/.github/workflows/discord-pr-merged.yml
+++ b/.github/workflows/discord-pr-merged.yml
@@ -1,0 +1,38 @@
+name: Discord - PR Merged
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  notify-discord:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate webhook secret
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "Missing required secret: DISCORD_WEBHOOK_URL"
+            exit 1
+          fi
+
+      - name: Post merge message to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          MERGED_BY: ${{ github.actor }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+
+          MESSAGE=$(python -c "import json, os; content=(f\"🚀 **PR Merged** in `{os.environ['REPOSITORY']}`\\n\" f\"**#{os.environ['PR_NUMBER']}:** {os.environ['PR_TITLE']}\\n\" f\"**Merged by:** {os.environ['MERGED_BY']}\\n\" f\"**Branch:** `{os.environ['HEAD_REF']}` → `{os.environ['BASE_REF']}`\\n\" f\"{os.environ['PR_URL']}\"); print(json.dumps({'content': content}))")
+
+          curl -fsS -X POST "$DISCORD_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data "$MESSAGE"

--- a/docs/discord-build-log.md
+++ b/docs/discord-build-log.md
@@ -1,0 +1,65 @@
+# Discord Build Log via GitHub Actions
+
+This repository includes three GitHub Actions workflows that post to Discord via `DISCORD_WEBHOOK_URL`:
+
+- `.github/workflows/discord-pr-approvals.yml` — posts when a PR review is submitted as `approved`.
+- `.github/workflows/discord-pr-merged.yml` — posts when a PR is merged.
+- `.github/workflows/discord-ci-status.yml` — posts CI pass/fail for the `CI` workflow on the default branch.
+
+## Setup
+
+1. **Create a read-only Discord channel** (for example `⚙️・build-log`).
+   - Allow members to view.
+   - Deny member send permissions.
+   - Allow only the webhook to post.
+2. **Create a Discord webhook** for that channel.
+   - In Discord: Channel Settings → Integrations → Webhooks → New Webhook.
+   - Copy the webhook URL.
+3. **Add the webhook URL as a GitHub Actions secret**.
+   - In GitHub: Repository Settings → Secrets and variables → Actions → New repository secret.
+   - Name: `DISCORD_WEBHOOK_URL`
+   - Value: your Discord webhook URL.
+
+## Message formats
+
+Approval:
+
+```text
+✅ **PR Approved** in `OWNER/REPO`
+**#<num>:** <title>
+**Approver:** <approver> • **Author:** <author>
+**Branch:** `<head>` → `<base>`
+<pr_url>
+```
+
+Merged:
+
+```text
+🚀 **PR Merged** in `OWNER/REPO`
+**#<num>:** <title>
+**Merged by:** <actor>
+**Branch:** `<head>` → `<base>`
+<pr_url>
+```
+
+CI:
+
+```text
+✅/❌ **CI <Passed/Failed>** in `OWNER/REPO`
+**Workflow:** <workflow_name>
+**Branch:** `<branch>`
+**Commit:** `<sha_short>`
+<run_url>
+```
+
+## How to test
+
+1. Open a test PR.
+2. Submit an **Approve** review on that PR and confirm the approval message appears in Discord.
+3. Merge the PR and confirm the merged message appears in Discord.
+4. Let CI run on the default branch and confirm a pass/fail CI message appears.
+
+## Notes
+
+- Workflows fail fast with a clear message if `DISCORD_WEBHOOK_URL` is missing.
+- Webhook secrets are never printed to logs.


### PR DESCRIPTION
### Motivation

- Provide a zero-hosting "rebuild feed" that posts PR approvals, merges, and CI results to a read-only Discord channel using GitHub Actions and a webhook secret.
- Avoid always-on services by leveraging existing GitHub Events (`pull_request_review`, `pull_request`, `workflow_run`) and a repository secret `DISCORD_WEBHOOK_URL`.

### Description

- Add `.github/workflows/discord-pr-approvals.yml` to trigger on `pull_request_review` (submitted) and post when `github.event.review.state == 'approved'` with the exact requested approval message format.
- Add `.github/workflows/discord-pr-merged.yml` to trigger on `pull_request` (closed) and post when `github.event.pull_request.merged == true` with the requested merge message format.
- Add `.github/workflows/discord-ci-status.yml` to trigger on `workflow_run` for the existing `CI` workflow and post pass/fail messages for completed runs on the default branch including workflow name, branch, short sha, and run URL.
- All workflows validate `DISCORD_WEBHOOK_URL` and fail fast with a clear message if missing, assemble the message content via a small Python snippet (to ensure JSON-escaping) and POST `{"content": "..."}` with `curl` while avoiding secret leakage to logs.
- Add `docs/discord-build-log.md` documenting setup (channel + webhook + secret), message formats, and how to test approvals/merges/CI notifications.

### Testing

- Ran the full test suite with `bun run test` and received: `1388 passed | 332 skipped` (all tests passed for this run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6307969108330bf07b20c9c110f8e)