### PR TITLE
docs: add Community Discord section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,14 @@ Browse [GitHub Issues](https://github.com/vermosi/offmeta/issues) for current ta
 
 ---
 
+## 💬 Community Discord
+
+Join the OffMeta community on Discord to share ideas, get help, and discuss deckbuilding:
+
+**Invite link:** [https://discord.com/invite/9UEv6vrTD4](https://discord.com/invite/9UEv6vrTD4)
+
+---
+
 ## 🔒 Security
 
 For security vulnerability reporting, see [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
### Motivation
- Provide a clear place in the project README for community engagement by adding an invite link to the project's Discord server.

### Description
- Add a new `## 💬 Community Discord` section to `README.md` containing the invite URL `https://discord.com/invite/9UEv6vrTD4` and place it between the Contributing and Security sections for visibility.

### Testing
- No automated tests were required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6326b07f4833097a453cf171b1436)