### PR TITLE
test: stabilize Index integration locale state

### DIFF
--- a/src/pages/__tests__/Index.integration.test.tsx
+++ b/src/pages/__tests__/Index.integration.test.tsx
@@ -153,6 +153,8 @@ let IndexPage: React.ComponentType;
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  localStorage.clear();
+  localStorage.setItem('offmeta-locale', 'en');
   mockTranslateQueryWithDedup.mockResolvedValue(
     createMockTranslation({ scryfallQuery: 'o:"treasure"' }),
   );


### PR DESCRIPTION
### Motivation
- The Index integration test was intermittently failing because locale state from other tests could change the rendered empty-state text, making the empty-state assertion flaky.

### Description
- Reset `localStorage` and explicitly set `offmeta-locale` to `'en'` in the `beforeEach` of `src/pages/__tests__/Index.integration.test.tsx` to ensure deterministic translations for the test.
- This change only touches the test setup and does not modify production code or behavior.

### Testing
- Ran `npm run test -- src/pages/__tests__/Index.integration.test.tsx`, which passed (all tests in that file succeeded). 
- Ran the full suite with `npm run test`, which completed with tests passing but Vitest reported one pre-existing unhandled `window is not defined` error from `src/lib/i18n/__tests__/locale-detection.test.ts`. 
- Attempted to run the Playwright E2E check `npx playwright test src/tests/e2e/search.spec.ts -g "typing a query and pressing Enter shows card results" --project=chromium`, but it failed because the Playwright Chromium binary is missing in the environment. 
- Attempted `npx playwright install chromium`, which failed due to the browser CDN returning HTTP 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6630bbb648330a23456c7e15c3560)