### PR TITLE
Add accessible names to CardModal Dialog/Drawer and close button

### DIFF
--- a/src/components/CardModal.tsx
+++ b/src/components/CardModal.tsx
@@ -347,7 +347,10 @@ export function CardModal({ card, open, onClose }: CardModalProps) {
   if (isMobile) {
     return (
       <Drawer open={open} onOpenChange={onClose} modal={false}>
-        <DrawerContent className="max-h-[90vh] px-0 overflow-hidden">
+        <DrawerContent
+          className="max-h-[90vh] px-0 overflow-hidden"
+          aria-label={card.name}
+        >
           <VisuallyHidden>
             <DrawerTitle>{card.name}</DrawerTitle>
           </VisuallyHidden>
@@ -356,6 +359,7 @@ export function CardModal({ card, open, onClose }: CardModalProps) {
             size="icon"
             className="absolute right-2 top-2 z-10 h-8 w-8"
             onClick={onClose}
+            aria-label="Close card details"
           >
             <X className="h-4 w-4" />
           </Button>
@@ -369,7 +373,10 @@ export function CardModal({ card, open, onClose }: CardModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-w-3xl w-[95vw] p-0 bg-background border-border/50 overflow-hidden max-h-[85vh] gap-0">
+      <DialogContent
+        className="max-w-3xl w-[95vw] p-0 bg-background border-border/50 overflow-hidden max-h-[85vh] gap-0"
+        aria-label={card.name}
+      >
         <VisuallyHidden>
           <DialogTitle>{card.name}</DialogTitle>
         </VisuallyHidden>


### PR DESCRIPTION
### Motivation
- Ensure the card modal exposes an explicit accessible name for both mobile (drawer) and desktop (dialog) containers and avoid icon-only control ambiguity for accessibility audits.

### Description
- Add `aria-label={card.name}` to the mobile `DrawerContent` and desktop `DialogContent` and add `aria-label="Close card details"` to the mobile close `Button` in `src/components/CardModal.tsx`, while keeping the existing visually hidden titles.

### Testing
- Ran `npm run lint` which succeeded.
- Ran `npm run typecheck` which succeeded.
- Attempted `npx playwright test src/tests/e2e/accessibility.spec.ts --project=chromium --grep "card modal has no critical or serious violations"`, but the e2e run is blocked because Playwright Chromium is not installed in this environment.
- Attempted `npx playwright install chromium` to provision browsers but the download failed with HTTP 403 in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a66317a8e88330b2e7c6e88cb75b43)