### PR TITLE
Mock `semantic-search` in accessibility e2e to stabilize card-modal test

### DIFF
--- a/src/tests/e2e/accessibility.spec.ts
+++ b/src/tests/e2e/accessibility.spec.ts
@@ -139,6 +139,18 @@ test.describe('Accessibility Audits @a11y', () => {
   test('card modal has no critical or serious violations', async ({
     page,
   }, testInfo) => {
+    await page.route('**/semantic-search**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          source: 'deterministic',
+          scryfallQuery: 'lightning bolt',
+        }),
+      });
+    });
+
     await page.route('**/api.scryfall.com/cards/search**', async (route) => {
       await route.fulfill({
         status: 200,


### PR DESCRIPTION
### Motivation
- The card-modal accessibility test was flaky because the UI depends on the `semantic-search` translation edge function to produce a `scryfallQuery`, which can be unavailable or slow in CI/non-network environments, causing no results to render and the test to fail.

### Description
- Updated `src/tests/e2e/accessibility.spec.ts` to add a Playwright route stub for `**/semantic-search**` that fulfills with a deterministic JSON payload (`{ success: true, source: 'deterministic', scryfallQuery: 'lightning bolt' }`) while keeping the existing Scryfall search mock intact so the modal-open path is deterministic.

### Testing
- Attempted to run `bun run playwright test src/tests/e2e/accessibility.spec.ts --project=chromium --grep "card modal has no critical or serious violations"`, but execution could not complete in this environment because the Playwright Chromium browser binary was not installed (`Executable doesn't exist ... chromium_headless_shell`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a66b159950833093b27c9860ec92b5)