### PR TITLE
docs: align on canonical npm testing workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,22 @@ See `docs/architecture.md` for full details. Key modules:
 ## Running Tests
 
 ```bash
-bun run test              # All tests
-bun run test -- --watch   # Watch mode
-bun run test -- src/lib/security  # Security suite only
+npm run test                    # All tests (canonical)
+npm run test:watch              # Watch mode (canonical)
+npm run test -- src/lib/security # Security suite only (canonical)
+```
+
+Optional Bun equivalents:
+
+```bash
+bun run test
+bun run test:watch
+bun run test -- src/lib/security
 ```
 
 ## PR Checklist
 
-- [ ] All tests pass (`bun run test`)
+- [ ] All tests pass (`npm run test`)
 - [ ] No `any` types introduced
 - [ ] RLS policies reviewed if DB changes
 - [ ] Semantic tokens used (no raw colors)

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Run security tests:
 
 ```bash
 npm run test -- src/lib/security
+# Optional equivalent: bun run test -- src/lib/security
 ```
 
 Run E2E and accessibility tests:

--- a/TESTING.md
+++ b/TESTING.md
@@ -2,6 +2,27 @@
 
 OffMeta uses [Vitest](https://vitest.dev/) for unit/integration tests and [Playwright](https://playwright.dev/) for E2E and accessibility tests, with **1,560+ tests** across multiple categories.
 
+## Tooling convention
+
+- **Canonical runner:** `npm` (matches CI workflows and required checks).
+- **Optional equivalent:** `bun` for local execution.
+
+Canonical commands:
+
+```bash
+npm run test          # Run all unit/integration tests
+npm run test:watch    # Watch mode
+npm run test -- --coverage  # With coverage report
+```
+
+Optional Bun equivalents:
+
+```bash
+bun run test
+bun run test:watch
+bun run test -- --coverage
+```
+
 ---
 
 ## Quick Start

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,10 @@ cp .env.example .env
 npm run dev
 ```
 
+## Tooling convention
+
+Use `npm` as the canonical task runner because CI and required checks run npm scripts. Bun is supported as an optional local equivalent for common test commands; see [`docs/testing.md`](./testing.md) for the canonical test command set.
+
 ## Project scripts
 
 - `npm run dev`: Start the Vite dev server

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,6 +2,27 @@
 
 OffMeta uses [Vitest](https://vitest.dev/) as the primary testing framework with 1,560+ tests across multiple categories.
 
+## Tooling convention
+
+- **Canonical runner:** `npm` (matches CI and required status checks).
+- **Optional equivalent:** `bun` for local runs if preferred.
+
+Canonical commands:
+
+```bash
+npm run test
+npm run test:watch
+npm run test -- --coverage
+```
+
+Optional Bun equivalents:
+
+```bash
+bun run test
+bun run test:watch
+bun run test -- --coverage
+```
+
 ## Run tests
 
 ```bash


### PR DESCRIPTION
### Motivation

- The repository previously mixed `bun` and `npm` in contributor-facing docs which could confuse contributors about the canonical test workflow.
- CI and required status checks run `npm` scripts, so documentation should reflect the runner used by automated checks.
- Allow `bun` as an optional local equivalent while making `npm` the canonical instruction to keep guidance aligned with CI.

### Description

- Standardized test command guidance in `AGENTS.md` to list `npm` as the canonical runner and added explicit optional `bun` equivalents. 
- Updated the PR checklist to reference `npm run test` as the required check. 
- Added a `Tooling convention` section and canonical command set to `docs/testing.md` and `TESTING.md` that describe `npm` as canonical and document `bun` as optional. 
- Added a short `Tooling convention` pointer to `docs/development.md` and added an optional `bun` note to `README.md` where security test execution is shown. 

### Testing

- No automated test suites were executed for this docs-only change. 
- The change was validated by checking that `package.json` and `.github/workflows/ci.yml` use `npm` for CI test execution and by verifying the updated documentation files compiled the expected canonical commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92de5b5808330838146c9cf05a058)