### PR TITLE
Standardize edge-function logging and quiet PWA info logs in production

### DIFF
--- a/src/lib/pwa/register.ts
+++ b/src/lib/pwa/register.ts
@@ -6,13 +6,27 @@
 
 import { registerSW } from 'virtual:pwa-register';
 
+const pwaDebugEnabled =
+  import.meta.env.DEV || import.meta.env.VITE_PWA_DEBUG === 'true';
+
+function logPwaInfo(message: string, metadata?: unknown): void {
+  if (!pwaDebugEnabled) return;
+
+  if (typeof metadata === 'undefined') {
+    console.log(message);
+    return;
+  }
+
+  console.log(message, metadata);
+}
+
 /**
  * Registers the service worker and sets up auto-update handling.
  * Called once on app initialization.
  */
 export function initPWA(): void {
   if (import.meta.env.DEV) {
-    console.log('[PWA] Skipping registration in development mode');
+    logPwaInfo('[PWA] Skipping registration in development mode');
     return;
   }
 
@@ -25,10 +39,10 @@ export function initPWA(): void {
         }
       },
       onOfflineReady() {
-        console.log('[PWA] App ready to work offline');
+        logPwaInfo('[PWA] App ready to work offline');
       },
       onRegistered(registration) {
-        console.log('[PWA] Service worker registered', registration);
+        logPwaInfo('[PWA] Service worker registered', registration);
 
         // Check for updates every hour
         if (registration) {

--- a/supabase/functions/_shared/logger.ts
+++ b/supabase/functions/_shared/logger.ts
@@ -1,0 +1,41 @@
+export type LogLevel = 'info' | 'warn' | 'error';
+
+export interface StructuredLogData {
+  [key: string]: unknown;
+}
+
+export function logEvent(
+  level: LogLevel,
+  event: string,
+  metadata: StructuredLogData = {},
+): void {
+  const payload = JSON.stringify({
+    level,
+    event,
+    timestamp: new Date().toISOString(),
+    ...metadata,
+  });
+
+  if (level === 'warn') {
+    console.warn(payload);
+    return;
+  }
+
+  if (level === 'error') {
+    console.error(payload);
+    return;
+  }
+
+  console.log(payload);
+}
+
+export function createLogger(scope: string) {
+  return {
+    info: (event: string, metadata: StructuredLogData = {}) =>
+      logEvent('info', event, { scope, ...metadata }),
+    warn: (event: string, metadata: StructuredLogData = {}) =>
+      logEvent('warn', event, { scope, ...metadata }),
+    error: (event: string, metadata: StructuredLogData = {}) =>
+      logEvent('error', event, { scope, ...metadata }),
+  };
+}

--- a/supabase/functions/cleanup-logs/index.ts
+++ b/supabase/functions/cleanup-logs/index.ts
@@ -13,6 +13,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { requireAdmin, getCorsHeaders } from '../_shared/auth.ts';
 import { validateEnv } from '../_shared/env.ts';
 import { checkRateLimit, maybeCleanup } from '../_shared/rateLimit.ts';
+import { createLogger } from '../_shared/logger.ts';
 
 const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = validateEnv([
   'SUPABASE_URL',
@@ -20,6 +21,7 @@ const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = validateEnv([
 ]);
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const logger = createLogger('cleanup-logs');
 
 const RETENTION_DAYS = 30;
 
@@ -37,12 +39,25 @@ serve(async (req) => {
 
   // Rate limiting: 1 req/min (batch job)
   maybeCleanup();
-  const clientIp = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  const { allowed, retryAfter } = await checkRateLimit(clientIp, undefined, 1, 10);
+  const clientIp =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const { allowed, retryAfter } = await checkRateLimit(
+    clientIp,
+    undefined,
+    1,
+    10,
+  );
   if (!allowed) {
     return new Response(
       JSON.stringify({ error: 'Rate limit exceeded', success: false }),
-      { status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) } },
+      {
+        status: 429,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+          'Retry-After': String(retryAfter),
+        },
+      },
     );
   }
 
@@ -53,9 +68,7 @@ serve(async (req) => {
     const cutoffDate = new Date();
     cutoffDate.setDate(cutoffDate.getDate() - RETENTION_DAYS);
 
-    console.log(
-      `Starting log cleanup. Deleting logs older than ${cutoffDate.toISOString()}`,
-    );
+    logger.info('cleanup_started', { cutoffDate: cutoffDate.toISOString() });
 
     // Delete old translation logs
     const { error: logsError, count: logsCount } = await supabase
@@ -76,22 +89,19 @@ serve(async (req) => {
       .lt('created_at', cutoffDate.toISOString());
 
     if (analyticsError) {
-      console.warn(
-        `Failed to delete analytics_events: ${analyticsError.message}`,
-      );
+      logger.warn('cleanup_analytics_delete_failed', {
+        error: analyticsError.message,
+      });
     }
 
     const responseTimeMs = Date.now() - startTime;
 
-    console.log(
-      JSON.stringify({
-        event: 'cleanup_complete',
-        deletedLogs: logsCount || 0,
-        deletedAnalytics: analyticsCount || 0,
-        cutoffDate: cutoffDate.toISOString(),
-        responseTimeMs,
-      }),
-    );
+    logger.info('cleanup_complete', {
+      deletedLogs: logsCount || 0,
+      deletedAnalytics: analyticsCount || 0,
+      cutoffDate: cutoffDate.toISOString(),
+      responseTimeMs,
+    });
 
     return new Response(
       JSON.stringify({
@@ -108,13 +118,10 @@ serve(async (req) => {
     );
   } catch (error) {
     const responseTimeMs = Date.now() - startTime;
-    console.error(
-      JSON.stringify({
-        event: 'cleanup_error',
-        error: String(error),
-        responseTimeMs,
-      }),
-    );
+    logger.error('cleanup_error', {
+      error: String(error),
+      responseTimeMs,
+    });
 
     return new Response(
       JSON.stringify({

--- a/supabase/functions/generate-patterns/index.ts
+++ b/supabase/functions/generate-patterns/index.ts
@@ -13,6 +13,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { requireAdmin, getCorsHeaders } from '../_shared/auth.ts';
 import { validateEnv } from '../_shared/env.ts';
 import { checkRateLimit, maybeCleanup } from '../_shared/rateLimit.ts';
+import { createLogger } from '../_shared/logger.ts';
 
 const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = validateEnv([
   'SUPABASE_URL',
@@ -20,6 +21,7 @@ const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } = validateEnv([
 ]);
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const logger = createLogger('generate-patterns');
 
 const MIN_OCCURRENCES = 2;
 const MIN_CONFIDENCE = 0.8;
@@ -51,12 +53,25 @@ serve(async (req) => {
 
   // Rate limiting: 1 req/min (batch job)
   maybeCleanup();
-  const clientIp = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  const { allowed, retryAfter } = await checkRateLimit(clientIp, undefined, 1, 10);
+  const clientIp =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const { allowed, retryAfter } = await checkRateLimit(
+    clientIp,
+    undefined,
+    1,
+    10,
+  );
   if (!allowed) {
     return new Response(
       JSON.stringify({ error: 'Rate limit exceeded', success: false }),
-      { status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) } },
+      {
+        status: 429,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+          'Retry-After': String(retryAfter),
+        },
+      },
     );
   }
 
@@ -75,14 +90,16 @@ serve(async (req) => {
       (existingRules || []).map((r) => normalizePattern(r.pattern)),
     );
 
-    console.log(`Found ${existingPatterns.size} existing patterns`);
+    logger.info('existing_patterns_loaded', { count: existingPatterns.size });
 
     const thirtyDaysAgo = new Date();
     thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
 
     const { data: logs, error: logsError } = await supabase
       .from('translation_logs')
-      .select('natural_language_query, translated_query, confidence_score, result_count')
+      .select(
+        'natural_language_query, translated_query, confidence_score, result_count',
+      )
       .gte('created_at', thirtyDaysAgo.toISOString())
       .gte('confidence_score', MIN_CONFIDENCE)
       .gte('result_count', MIN_RESULT_COUNT)
@@ -108,7 +125,7 @@ serve(async (req) => {
       );
     }
 
-    console.log(`Analyzing ${logs.length} translation logs`);
+    logger.info('translation_logs_analyzing', { count: logs.length });
 
     interface QueryData {
       count: number;
@@ -127,7 +144,10 @@ serve(async (req) => {
 
       if (existing) {
         existing.count++;
-        existing.minResultCount = Math.min(existing.minResultCount, resultCount);
+        existing.minResultCount = Math.min(
+          existing.minResultCount,
+          resultCount,
+        );
         if (log.confidence_score > existing.bestConfidence) {
           existing.bestTranslation = log.translated_query;
           existing.bestConfidence = log.confidence_score;
@@ -153,7 +173,7 @@ serve(async (req) => {
       .sort((a, b) => b[1].count - a[1].count)
       .slice(0, MAX_NEW_PATTERNS);
 
-    console.log(`Found ${candidates.length} candidates for new patterns`);
+    logger.info('pattern_candidates_found', { count: candidates.length });
 
     if (candidates.length === 0) {
       return new Response(
@@ -189,14 +209,11 @@ serve(async (req) => {
 
     const patternsCreated = inserted?.length || 0;
 
-    console.log(
-      JSON.stringify({
-        event: 'patterns_generated',
-        patternsCreated,
-        analyzed: logs.length,
-        timeMs: Date.now() - startTime,
-      }),
-    );
+    logger.info('patterns_generated', {
+      patternsCreated,
+      analyzed: logs.length,
+      timeMs: Date.now() - startTime,
+    });
 
     return new Response(
       JSON.stringify({
@@ -212,7 +229,9 @@ serve(async (req) => {
       },
     );
   } catch (error) {
-    console.error('Pattern generation error:', error);
+    logger.error('pattern_generation_error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return new Response(
       JSON.stringify({
         success: false,

--- a/supabase/functions/process-feedback/index.ts
+++ b/supabase/functions/process-feedback/index.ts
@@ -12,13 +12,19 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 
 import { checkRateLimit, resolveRateLimitKey } from '../_shared/rateLimit.ts';
-import { getCorsHeaders, validateAuth, logAuthFailure } from '../_shared/auth.ts';
+import {
+  getCorsHeaders,
+  validateAuth,
+  logAuthFailure,
+} from '../_shared/auth.ts';
 import { validateEnv } from '../_shared/env.ts';
+import { createLogger } from '../_shared/logger.ts';
 
 const { LOVABLE_API_KEY, SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } =
   validateEnv(['LOVABLE_API_KEY', 'SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']);
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+const logger = createLogger('process-feedback');
 
 serve(async (req) => {
   const corsHeaders = getCorsHeaders(req);
@@ -29,9 +35,16 @@ serve(async (req) => {
   // Authentication check - require valid token (anon key, service role, or JWT)
   const authResult = await validateAuth(req);
   if (!authResult.authorized) {
-    await logAuthFailure(req, authResult.error || 'Unauthorized', 'process-feedback');
+    await logAuthFailure(
+      req,
+      authResult.error || 'Unauthorized',
+      'process-feedback',
+    );
     return new Response(
-      JSON.stringify({ error: authResult.error || 'Unauthorized', success: false }),
+      JSON.stringify({
+        error: authResult.error || 'Unauthorized',
+        success: false,
+      }),
       {
         status: 401,
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
@@ -256,13 +269,15 @@ serve(async (req) => {
           processed_at: new Date().toISOString(),
         })
         .in('id', stuckIds);
-      console.log(`Reset ${stuckIds.length} stuck processing items to failed`);
+      logger.info('stuck_processing_items_reset', { count: stuckIds.length });
     }
 
     for (const feedback of pendingFeedback) {
       // Safety timeout: if processing takes > 25s, mark as failed
       const safetyTimeout = setTimeout(async () => {
-        console.error(`Safety timeout hit for feedback ${feedback.id}`);
+        logger.error('feedback_processing_safety_timeout', {
+          feedbackId: feedback.id,
+        });
         await supabase
           .from('search_feedback')
           .update({
@@ -365,14 +380,17 @@ IMPORTANT: Only output the JSON object, nothing else.`;
 
         if (!response.ok) {
           const errorText = await response.text();
-          console.error('AI API error:', response.status, errorText);
+          logger.error('ai_api_error', { status: response.status, errorText });
           throw new Error(`AI API error: ${response.status}`);
         }
 
         const aiData = await response.json();
         const aiResponse = aiData.choices?.[0]?.message?.content || '';
 
-        console.log('AI response for feedback', feedback.id, ':', aiResponse);
+        logger.info('ai_response_received', {
+          feedbackId: feedback.id,
+          aiResponse,
+        });
 
         // Parse the JSON response
         let ruleData;
@@ -382,7 +400,13 @@ IMPORTANT: Only output the JSON object, nothing else.`;
           if (!jsonMatch) throw new Error('No JSON found in response');
           ruleData = JSON.parse(jsonMatch[0]);
         } catch (parseError) {
-          console.error('Failed to parse AI response:', parseError);
+          logger.error('ai_response_parse_error', {
+            feedbackId: feedback.id,
+            error:
+              parseError instanceof Error
+                ? parseError.message
+                : String(parseError),
+          });
           await supabase
             .from('search_feedback')
             .update({
@@ -460,19 +484,21 @@ IMPORTANT: Only output the JSON object, nothing else.`;
         } catch (fetchErr) {
           // Network error — treat as inconclusive, allow the rule through
           // to avoid blocking rules on transient Scryfall downtime
-          console.warn(
-            `Scryfall validation network error for feedback ${feedback.id}:`,
-            fetchErr,
-          );
+          logger.warn('scryfall_validation_network_error', {
+            feedbackId: feedback.id,
+            error:
+              fetchErr instanceof Error ? fetchErr.message : String(fetchErr),
+          });
           scryfallOk = true; // fail-open on network errors
         }
 
         if (!scryfallOk) {
-          console.warn(
-            `Scryfall validation FAILED (attempt 1) for feedback ${feedback.id}:`,
-            scryfallError,
-            `| syntax: "${ruleData.scryfall_syntax}" — asking AI to self-correct`,
-          );
+          logger.warn('scryfall_validation_failed_attempt_1', {
+            feedbackId: feedback.id,
+            error: scryfallError,
+            scryfallSyntax: ruleData.scryfall_syntax,
+            nextStep: 'request_ai_self_correction',
+          });
 
           // ──────────────────────────────────────────────────────────────────
           // SELF-CORRECTION: give the AI one chance to fix the broken syntax.
@@ -541,17 +567,20 @@ Respond in this EXACT JSON format only (no other text):
                 correctedRuleData.scryfall_syntax = normalizeTagAliases(
                   correctedRuleData.scryfall_syntax,
                 );
-                console.log(
-                  `AI self-correction for feedback ${feedback.id}:`,
-                  correctedRuleData.scryfall_syntax,
-                );
+                logger.info('ai_self_correction_generated', {
+                  feedbackId: feedback.id,
+                  scryfallSyntax: correctedRuleData.scryfall_syntax,
+                });
               }
             }
           } catch (correctionErr) {
-            console.error(
-              `Self-correction AI call failed for feedback ${feedback.id}:`,
-              correctionErr,
-            );
+            logger.error('ai_self_correction_failed', {
+              feedbackId: feedback.id,
+              error:
+                correctionErr instanceof Error
+                  ? correctionErr.message
+                  : String(correctionErr),
+            });
           }
 
           // Validate the corrected syntax against Scryfall
@@ -575,33 +604,38 @@ Respond in this EXACT JSON format only (no other text):
                   correctionOk = true;
                   scryfallTotalCards = correctionCards;
                   ruleData = correctedRuleData;
-                  console.log(
-                    `Self-correction PASSED for feedback ${feedback.id}:`,
-                    `"${ruleData.scryfall_syntax}" returned ${scryfallTotalCards} cards`,
-                  );
+                  logger.info('self_correction_validation_passed', {
+                    feedbackId: feedback.id,
+                    scryfallSyntax: ruleData.scryfall_syntax,
+                    scryfallTotalCards,
+                  });
                 } else {
-                  console.error(
-                    `Self-correction also returned 0 results for feedback ${feedback.id}`,
-                  );
+                  logger.error('self_correction_zero_results', {
+                    feedbackId: feedback.id,
+                  });
                 }
               } else {
                 await correctionResp.text();
-                console.error(
-                  `Self-correction Scryfall returned ${correctionResp.status} for feedback ${feedback.id}`,
-                );
+                logger.error('self_correction_scryfall_http_error', {
+                  feedbackId: feedback.id,
+                  status: correctionResp.status,
+                });
               }
             } catch (correctionFetchErr) {
-              console.warn(
-                `Self-correction validation network error for feedback ${feedback.id}:`,
-                correctionFetchErr,
-              );
+              logger.warn('self_correction_validation_network_error', {
+                feedbackId: feedback.id,
+                error:
+                  correctionFetchErr instanceof Error
+                    ? correctionFetchErr.message
+                    : String(correctionFetchErr),
+              });
             }
           }
 
           if (!correctionOk) {
-            console.error(
-              `Both validation attempts FAILED for feedback ${feedback.id}. Marking as failed.`,
-            );
+            logger.error('validation_attempts_failed', {
+              feedbackId: feedback.id,
+            });
             await supabase
               .from('search_feedback')
               .update({
@@ -619,10 +653,11 @@ Respond in this EXACT JSON format only (no other text):
           scryfallOk = true;
         }
 
-        console.log(
-          `Scryfall validation PASSED for feedback ${feedback.id}:`,
-          `"${ruleData.scryfall_syntax}" returned ${scryfallTotalCards} cards`,
-        );
+        logger.info('scryfall_validation_passed', {
+          feedbackId: feedback.id,
+          scryfallSyntax: ruleData.scryfall_syntax,
+          scryfallTotalCards,
+        });
 
         // Persist the validated card count so admins can see rule breadth
         await supabase
@@ -669,12 +704,10 @@ Respond in this EXACT JSON format only (no other text):
               rule: `${ruleData.pattern} → ${ruleData.scryfall_syntax} (was: ${existingRule[0].scryfall_syntax})`,
             });
 
-            console.log(
-              'Updated existing rule from retry feedback:',
-              ruleData.pattern,
-              '→',
-              ruleData.scryfall_syntax,
-            );
+            logger.info('existing_rule_updated_from_retry_feedback', {
+              pattern: ruleData.pattern,
+              scryfallSyntax: ruleData.scryfall_syntax,
+            });
             continue;
           } else {
             // First time seeing this, but pattern exists - mark as duplicate
@@ -727,19 +760,18 @@ Respond in this EXACT JSON format only (no other text):
           rule: `${ruleData.pattern} → ${ruleData.scryfall_syntax}`,
         });
 
-        console.log(
-          'Generated rule from feedback:',
-          ruleData.pattern,
-          '→',
-          ruleData.scryfall_syntax,
-        );
+        logger.info('rule_generated_from_feedback', {
+          pattern: ruleData.pattern,
+          scryfallSyntax: ruleData.scryfall_syntax,
+        });
       } catch (processingError) {
-        console.error(
-          'Error processing feedback',
-          feedback.id,
-          ':',
-          processingError,
-        );
+        logger.error('feedback_processing_error', {
+          feedbackId: feedback.id,
+          error:
+            processingError instanceof Error
+              ? processingError.message
+              : String(processingError),
+        });
         await supabase
           .from('search_feedback')
           .update({
@@ -768,7 +800,9 @@ Respond in this EXACT JSON format only (no other text):
       },
     );
   } catch (error) {
-    console.error('Process feedback error:', error);
+    logger.error('process_feedback_error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return new Response(
       JSON.stringify({
         error: 'Failed to process feedback',

--- a/supabase/functions/semantic-search/circuit-breaker.ts
+++ b/supabase/functions/semantic-search/circuit-breaker.ts
@@ -1,3 +1,7 @@
+import { createLogger } from './logging.ts';
+
+const logger = createLogger('circuit-breaker');
+
 // ============= CIRCUIT BREAKER =============
 const circuitBreaker = {
   failures: 0,
@@ -15,7 +19,7 @@ export function isCircuitOpen(): boolean {
   const now = Date.now();
   if (now - circuitBreaker.lastFailure > CIRCUIT_RESET_TIMEOUT) {
     // Reset to half-open
-    console.log('Circuit breaker entering half-open state');
+    logger.logInfo('circuit_breaker_half_open');
     return false;
   }
   return true;
@@ -27,7 +31,9 @@ export function recordCircuitFailure(): void {
 
   if (circuitBreaker.failures >= CIRCUIT_FAILURE_THRESHOLD) {
     if (!circuitBreaker.isOpen) {
-      console.warn('Circuit breaker OPENED - too many AI gateway failures');
+      logger.logWarn('circuit_breaker_opened', {
+        reason: 'too_many_ai_gateway_failures',
+      });
       circuitBreaker.isOpen = true;
     }
   }
@@ -35,7 +41,7 @@ export function recordCircuitFailure(): void {
 
 export function recordCircuitSuccess(): void {
   if (circuitBreaker.isOpen || circuitBreaker.failures > 0) {
-    console.log('Circuit breaker RESET');
+    logger.logInfo('circuit_breaker_reset');
     circuitBreaker.failures = 0;
     circuitBreaker.isOpen = false;
     circuitBreaker.halfOpenAttempts = 0;

--- a/supabase/functions/semantic-search/matching.ts
+++ b/supabase/functions/semantic-search/matching.ts
@@ -1,6 +1,9 @@
 import { SYNONYM_MAP } from './shared-mappings.ts';
 import { supabase } from './client.ts';
 import { type CacheEntry } from './cache.ts';
+import { createLogger } from './logging.ts';
+
+const logger = createLogger('pattern-matching');
 
 /**
  * Hardcoded translations for warmup/prefetch queries.
@@ -8,7 +11,8 @@ import { type CacheEntry } from './cache.ts';
  */
 const HARDCODED_TRANSLATIONS: Record<string, CacheEntry['result']> = {
   'mana rocks': {
-    scryfallQuery: 't:artifact o:"add" (o:"{C}" or o:"{W}" or o:"{U}" or o:"{B}" or o:"{R}" or o:"{G}" or o:"any color" or o:"one mana")',
+    scryfallQuery:
+      't:artifact o:"add" (o:"{C}" or o:"{W}" or o:"{U}" or o:"{B}" or o:"{R}" or o:"{G}" or o:"any color" or o:"one mana")',
     explanation: {
       readable: 'Artifacts that produce mana (mana rocks)',
       assumptions: [],
@@ -66,7 +70,7 @@ export async function checkPatternMatch(
   // Check hardcoded translations first (zero latency)
   const normalizedLower = query.toLowerCase().trim();
   if (HARDCODED_TRANSLATIONS[normalizedLower]) {
-    console.log(`Hardcoded match: "${query}"`);
+    logger.logInfo('hardcoded_pattern_match', { query });
     return HARDCODED_TRANSLATIONS[normalizedLower];
   }
 
@@ -84,9 +88,10 @@ export async function checkPatternMatch(
     for (const rule of rules) {
       const normalizedPattern = normalizeQueryForMatching(rule.pattern);
       if (normalizedPattern === normalizedQuery) {
-        console.log(
-          `Pattern match found: "${query}" → "${rule.scryfall_syntax}"`,
-        );
+        logger.logInfo('translation_pattern_match_found', {
+          query,
+          translatedQuery: rule.scryfall_syntax,
+        });
 
         return {
           scryfallQuery: rule.scryfall_syntax,
@@ -101,7 +106,9 @@ export async function checkPatternMatch(
     }
     return null;
   } catch (e) {
-    console.error('Pattern match error:', e);
+    logger.logWarn('translation_pattern_match_error', {
+      error: e instanceof Error ? e.message : String(e),
+    });
     return null;
   }
 }

--- a/supabase/functions/semantic-search/validation.ts
+++ b/supabase/functions/semantic-search/validation.ts
@@ -1,5 +1,8 @@
 import { KNOWN_OTAGS } from './tags.ts';
 import { VALID_SEARCH_KEYS } from './constants.ts';
+import { createLogger } from './logging.ts';
+
+const logger = createLogger('validation');
 
 export interface ValidationCase {
   name: string;
@@ -270,10 +273,10 @@ export function validateQuery(query: string): {
     }
     // Clean up orphaned boolean operators left after stripping tags
     sanitized = sanitized
-      .replace(/\bor(\s+or)+\b/gi, 'or')   // "or or" → "or"
-      .replace(/\(\s*or\b/g, '(')           // "( or …" → "( …"
-      .replace(/\bor\s*\)/g, ')')           // "… or )" → "… )"
-      .replace(/\(\s*\)/g, '')              // "()" → ""
+      .replace(/\bor(\s+or)+\b/gi, 'or') // "or or" → "or"
+      .replace(/\(\s*or\b/g, '(') // "( or …" → "( …"
+      .replace(/\bor\s*\)/g, ')') // "… or )" → "… )"
+      .replace(/\(\s*\)/g, '') // "()" → ""
       .replace(/\s+/g, ' ')
       .trim();
   }
@@ -298,8 +301,11 @@ export function validateQuery(query: string): {
   }
 
   // Count single quotes that are NOT apostrophes (word-internal like "Thassa's" or plural possessive like "Praetors'")
-  const strippedOfApostrophes = sanitized.replace(/\w'\w/g, '').replace(/\w'(?=\s|$)/g, '');
-  const nonApostropheSingleQuotes = (strippedOfApostrophes.match(/'/g) || []).length;
+  const strippedOfApostrophes = sanitized
+    .replace(/\w'\w/g, '')
+    .replace(/\w'(?=\s|$)/g, '');
+  const nonApostropheSingleQuotes = (strippedOfApostrophes.match(/'/g) || [])
+    .length;
   if (nonApostropheSingleQuotes % 2 !== 0) {
     sanitized = sanitized + "'";
     issues.push('Added missing closing quote');
@@ -508,8 +514,14 @@ export function applyAutoCorrections(
     );
     // Also remove is:commander when f:commander is more appropriate
     // (stax queries want format legality, not "can be commander")
-    if (/\bis:commander\b/i.test(correctedQuery) && !/\bf:commander\b/i.test(correctedQuery)) {
-      correctedQuery = correctedQuery.replace(/\bis:commander\b/gi, 'f:commander');
+    if (
+      /\bis:commander\b/i.test(correctedQuery) &&
+      !/\bf:commander\b/i.test(correctedQuery)
+    ) {
+      correctedQuery = correctedQuery.replace(
+        /\bis:commander\b/gi,
+        'f:commander',
+      );
     }
     correctedQuery = correctedQuery.replace(/\s+/g, ' ').trim();
     if (correctedQuery !== beforeFix) {
@@ -608,10 +620,8 @@ export function runValidationTables(): void {
   }
 
   if (failures.length > 0) {
-    console.warn(
-      JSON.stringify({ event: 'validation_table_failed', failures }),
-    );
+    logger.logWarn('validation_table_failed', { failures });
   } else {
-    console.log(JSON.stringify({ event: 'validation_table_passed' }));
+    logger.logInfo('validation_table_passed');
   }
 }

--- a/supabase/functions/warmup-cache/index.ts
+++ b/supabase/functions/warmup-cache/index.ts
@@ -14,6 +14,7 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { requireAdmin, getCorsHeaders } from '../_shared/auth.ts';
 import { validateEnv } from '../_shared/env.ts';
 import { checkRateLimit, maybeCleanup } from '../_shared/rateLimit.ts';
+import { createLogger } from '../_shared/logger.ts';
 
 const { SUPABASE_URL, SUPABASE_ANON_KEY } = validateEnv([
   'SUPABASE_URL',
@@ -21,6 +22,7 @@ const { SUPABASE_URL, SUPABASE_ANON_KEY } = validateEnv([
 ]);
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+const logger = createLogger('warmup-cache');
 
 // Common MTG queries that should be pre-cached
 const COMMON_QUERIES = [
@@ -41,7 +43,7 @@ const COMMON_QUERIES = [
   'Gitaxian Probe',
   'Inquisition of Kozilek',
   'Mana Crypt',
-  'Nature\'s Lore',
+  "Nature's Lore",
   'Opt',
   'Serum Visions',
   'Skullclamp',
@@ -62,7 +64,7 @@ const COMMON_QUERIES = [
   'Wasteland',
   'Wooded Foothills',
   'Strip Mine',
-  'Thespian\'s Stage',
+  "Thespian's Stage",
   'Crop Rotation',
   'Exploration',
   'Life from the Loam',
@@ -73,7 +75,7 @@ const COMMON_QUERIES = [
   'Enlightened Tutor',
   'Worldly Tutor',
   'Chord of Calling',
-  'Green Sun\'s Zenith',
+  "Green Sun's Zenith",
   'Imperial Seal',
   'Wheel of Fortune',
   'Windfall',
@@ -85,7 +87,7 @@ const COMMON_QUERIES = [
   'Force of Negation',
   'Mana Drain',
   'Cyclonic Rift',
-  'Teferi\'s Protection',
+  "Teferi's Protection",
   'Smothering Tithe',
   'Dockside Extortionist',
   'Esper Sentinel',
@@ -93,7 +95,7 @@ const COMMON_QUERIES = [
   'Aura Shards',
   'Beast Within',
   'Generous Gift',
-  'Assassin\'s Trophy',
+  "Assassin's Trophy",
   'Anguished Unmaking',
   'Vandalblast',
   'Austere Command',
@@ -110,7 +112,7 @@ const COMMON_QUERIES = [
   'Collector Ouphe',
   'Stranglehold',
   'Rule of Law',
-  'Grafdigger\'s Cage',
+  "Grafdigger's Cage",
   'Rest in Peace',
   'Torpor Orb',
   'Cursed Totem',
@@ -119,13 +121,13 @@ const COMMON_QUERIES = [
   'Ravages of War',
   'Muldrotha, the Gravetide',
   'The Gitrog Monster',
-  'Yuriko, the Tiger\'s Shadow',
+  "Yuriko, the Tiger's Shadow",
   'Korvold, Fae-Cursed King',
   'Chulane, Teller of Tales',
   'Kenrith, the Returned King',
   'Urza, Lord High Artificer',
   'Golos, Tireless Pilgrim',
-  'Atraxa, Praetors\' Voice',
+  "Atraxa, Praetors' Voice",
   'Breya, Etherium Shaper',
   'Najeela, the Blade-Blossom',
   'Tayam, Luminous Enigma',
@@ -159,11 +161,11 @@ const COMMON_QUERIES = [
   'Otawara, Soaring City',
   'Sokenzan, Crucible of Defiance',
   'Eiganjo, Seat of the Empire',
-  'Minamo, School at Water\'s Edge',
+  "Minamo, School at Water's Edge",
   'Yargle and Multani',
   'Rocco, Cabaretti Caterer',
   'Jetmir, Nexus of Revels',
-  'Jinnie Fay, Jetmir\'s Second',
+  "Jinnie Fay, Jetmir's Second",
   'Henzie "Toolbox" Torre',
   'Prosper, Tome-Bound',
   'Sefris of the Hidden Ways',
@@ -183,7 +185,7 @@ const COMMON_QUERIES = [
   'Miirym, Sentinel Wyrm',
   'Scion of the Ur-Dragon',
   'Korlessa, Scale Singer',
-  'Kykar, Wind\'s Fury',
+  "Kykar, Wind's Fury",
   'Niv-Mizzet, Parun',
   'The Locust God',
   'Brudiclad, Telchor Engineer',
@@ -194,60 +196,138 @@ const COMMON_QUERIES = [
   'Torbran, Thane of Red Fell',
   'Purphoros, God of the Forge',
   'Emmara, Soul of the Accord',
-  'Trostani, Selesnya\'s Voice',
+  "Trostani, Selesnya's Voice",
   'Karametra, God of Harvests',
   'Qausali Ambusher',
   'Ramp & Mana',
-  'green ramp', 'mana dorks', 'mana rocks', 'land ramp', 'artifact ramp',
-  'cheap mana rocks', 'mana rocks under $5', 'two mana rocks', 'sol ring alternatives',
+  'green ramp',
+  'mana dorks',
+  'mana rocks',
+  'land ramp',
+  'artifact ramp',
+  'cheap mana rocks',
+  'mana rocks under $5',
+  'two mana rocks',
+  'sol ring alternatives',
   // Card Draw
-  'blue card draw', 'black card draw', 'green card draw', 'card draw engines',
-  'cantrips', 'wheel effects',
+  'blue card draw',
+  'black card draw',
+  'green card draw',
+  'card draw engines',
+  'cantrips',
+  'wheel effects',
   // Removal
-  'white removal', 'black removal', 'creature removal', 'artifact removal',
-  'enchantment removal', 'board wipes', 'cheap board wipes', 'single target removal',
+  'white removal',
+  'black removal',
+  'creature removal',
+  'artifact removal',
+  'enchantment removal',
+  'board wipes',
+  'cheap board wipes',
+  'single target removal',
   // Counterspells
-  'blue counterspells', 'cheap counterspells', 'two mana counterspells', 'free counterspells',
+  'blue counterspells',
+  'cheap counterspells',
+  'two mana counterspells',
+  'free counterspells',
   // Tutors
-  'black tutors', 'green tutors', 'creature tutors', 'land tutors',
-  'artifact tutors', 'enchantment tutors',
+  'black tutors',
+  'green tutors',
+  'creature tutors',
+  'land tutors',
+  'artifact tutors',
+  'enchantment tutors',
   // Tribal
-  'elf tribal', 'goblin tribal', 'zombie tribal', 'vampire tribal',
-  'dragon tribal', 'angel tribal', 'merfolk tribal', 'human tribal',
-  'sliver tribal', 'elf lords', 'goblin lords', 'zombie lords',
+  'elf tribal',
+  'goblin tribal',
+  'zombie tribal',
+  'vampire tribal',
+  'dragon tribal',
+  'angel tribal',
+  'merfolk tribal',
+  'human tribal',
+  'sliver tribal',
+  'elf lords',
+  'goblin lords',
+  'zombie lords',
   // Sacrifice
-  'sacrifice outlets', 'free sacrifice outlets', 'aristocrats',
-  'blood artist effects', 'death triggers', 'grave pact effects',
+  'sacrifice outlets',
+  'free sacrifice outlets',
+  'aristocrats',
+  'blood artist effects',
+  'death triggers',
+  'grave pact effects',
   // Graveyard
-  'reanimation spells', 'self mill', 'graveyard recursion',
-  'graveyard hate', 'flashback spells',
+  'reanimation spells',
+  'self mill',
+  'graveyard recursion',
+  'graveyard hate',
+  'flashback spells',
   // Tokens
-  'token generators', 'treasure token makers', 'token doublers', 'populate effects',
+  'token generators',
+  'treasure token makers',
+  'token doublers',
+  'populate effects',
   // Combat
-  'haste enablers', 'extra combat steps', 'double strike',
-  'unblockable creatures', 'trample enablers',
+  'haste enablers',
+  'extra combat steps',
+  'double strike',
+  'unblockable creatures',
+  'trample enablers',
   // Control
-  'stax pieces', 'hatebears', 'pillowfort', 'protection spells',
+  'stax pieces',
+  'hatebears',
+  'pillowfort',
+  'protection spells',
   // Blink
-  'blink effects', 'flicker effects', 'etb creatures',
+  'blink effects',
+  'flicker effects',
+  'etb creatures',
   // Commander Specific
-  'partner commanders', 'mono red commanders', 'mono green commanders',
-  'mono blue commanders', 'mono black commanders', 'mono white commanders',
-  'simic commanders', 'rakdos commanders', 'orzhov commanders',
+  'partner commanders',
+  'mono red commanders',
+  'mono green commanders',
+  'mono blue commanders',
+  'mono black commanders',
+  'mono white commanders',
+  'simic commanders',
+  'rakdos commanders',
+  'orzhov commanders',
   // Color Combinations
-  'rakdos sacrifice', 'simic ramp', 'orzhov lifegain', 'gruul creatures',
-  'azorius control', 'dimir mill', 'golgari graveyard', 'boros aggro',
-  'izzet spellslinger', 'selesnya tokens',
+  'rakdos sacrifice',
+  'simic ramp',
+  'orzhov lifegain',
+  'gruul creatures',
+  'azorius control',
+  'dimir mill',
+  'golgari graveyard',
+  'boros aggro',
+  'izzet spellslinger',
+  'selesnya tokens',
   // Budget
-  'cheap green creatures', 'budget removal', 'affordable tutors', 'budget mana rocks',
+  'cheap green creatures',
+  'budget removal',
+  'affordable tutors',
+  'budget mana rocks',
   // Lands
-  'fetch lands', 'shock lands', 'dual lands', 'pain lands',
-  'tri lands', 'modal lands', 'creature lands',
+  'fetch lands',
+  'shock lands',
+  'dual lands',
+  'pain lands',
+  'tri lands',
+  'modal lands',
+  'creature lands',
   // Special Effects
-  'extra turn spells', 'copy effects', 'theft effects',
-  'mind control', 'clone effects', 'polymorph effects',
+  'extra turn spells',
+  'copy effects',
+  'theft effects',
+  'mind control',
+  'clone effects',
+  'polymorph effects',
   // Recent/Popular
-  'new commanders', 'popular commander cards', 'staple cards',
+  'new commanders',
+  'popular commander cards',
+  'staple cards',
 ];
 
 serve(async (req) => {
@@ -264,12 +344,25 @@ serve(async (req) => {
 
   // Rate limiting: 1 req/min (batch job)
   maybeCleanup();
-  const clientIp = req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
-  const { allowed, retryAfter } = await checkRateLimit(clientIp, undefined, 1, 10);
+  const clientIp =
+    req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || 'unknown';
+  const { allowed, retryAfter } = await checkRateLimit(
+    clientIp,
+    undefined,
+    1,
+    10,
+  );
   if (!allowed) {
     return new Response(
       JSON.stringify({ error: 'Rate limit exceeded', success: false }),
-      { status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json', 'Retry-After': String(retryAfter) } },
+      {
+        status: 429,
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+          'Retry-After': String(retryAfter),
+        },
+      },
     );
   }
 
@@ -292,13 +385,10 @@ serve(async (req) => {
     const queriesToWarm =
       customQueries.length > 0 ? customQueries : COMMON_QUERIES;
 
-    console.log(
-      JSON.stringify({
-        event: 'warmup_started',
-        queryCount: queriesToWarm.length,
-        custom: customQueries.length > 0,
-      }),
-    );
+    logger.info('warmup_started', {
+      queryCount: queriesToWarm.length,
+      custom: customQueries.length > 0,
+    });
 
     const results = {
       total: queriesToWarm.length,
@@ -325,26 +415,29 @@ serve(async (req) => {
           );
 
           if (error) {
-            console.error(`Warmup failed for "${query}":`, error.message);
+            logger.error('warmup_query_failed', {
+              query,
+              error: error.message,
+            });
             results.failed++;
             results.errors.push(`${query}: ${error.message}`);
           } else if (data?.cached) {
             results.skipped++;
           } else if (data?.success) {
             results.successful++;
-            console.log(
-              JSON.stringify({
-                event: 'query_warmed',
-                query: query.substring(0, 50),
-                confidence: data.explanation?.confidence,
-              }),
-            );
+            logger.info('query_warmed', {
+              query: query.substring(0, 50),
+              confidence: data.explanation?.confidence,
+            });
           } else {
             results.failed++;
             results.errors.push(`${query}: Unknown error`);
           }
         } catch (err) {
-          console.error(`Warmup exception for "${query}":`, err);
+          logger.error('warmup_query_exception', {
+            query,
+            error: err instanceof Error ? err.message : String(err),
+          });
           results.failed++;
           results.errors.push(`${query}: ${String(err)}`);
         }
@@ -362,13 +455,10 @@ serve(async (req) => {
 
     const duration = Date.now() - startTime;
 
-    console.log(
-      JSON.stringify({
-        event: 'warmup_complete',
-        ...results,
-        durationMs: duration,
-      }),
-    );
+    logger.info('warmup_complete', {
+      ...results,
+      durationMs: duration,
+    });
 
     return new Response(
       JSON.stringify({
@@ -395,7 +485,9 @@ serve(async (req) => {
       },
     );
   } catch (error) {
-    console.error('Warmup error:', error);
+    logger.error('warmup_error', {
+      error: error instanceof Error ? error.message : String(error),
+    });
     return new Response(
       JSON.stringify({
         success: false,


### PR DESCRIPTION
### Motivation

- Reduce ad-hoc `console.*` usage in edge functions and semantic-search internals to provide consistent, structured observability across deployments.  
- Emit structured JSON logs (`level`, `event`, `timestamp`, metadata) to aid parsing and analysis in centralized logging systems.  
- Prevent verbose informational PWA logs from showing in production by gating them behind an explicit debug flag.

### Description

- Added a shared structured logger at `supabase/functions/_shared/logger.ts` that exposes `logEvent` and `createLogger(scope)` and emits JSON payloads for `info`, `warn`, and `error`.  
- Replaced direct `console.*` calls in semantic-search modules to use the existing structured logger (`createLogger`) in `supabase/functions/semantic-search/matching.ts`, `supabase/functions/semantic-search/circuit-breaker.ts`, and `supabase/functions/semantic-search/validation.ts`.  
- Replaced `console.*` usage in edge functions `process-feedback`, `generate-patterns`, `warmup-cache`, and `cleanup-logs` to use the new shared logger and added scoped events/metadata for key operational points.  
- Updated `src/lib/pwa/register.ts` to gate informational PWA logs behind `pwaDebugEnabled = import.meta.env.DEV || import.meta.env.VITE_PWA_DEBUG === 'true'` and use a small `logPwaInfo` helper so production users are not exposed to verbose messages while leaving error logs intact.

### Testing

- Ran a targeted lint of modified files with `npx eslint` against the changed set (semantic-search, process-feedback, generate-patterns, warmup-cache, cleanup-logs, PWA register, and the new `_shared/logger.ts`) which completed successfully.  
- Ran the full lint suite with `npm run lint` which failed due to pre-existing unrelated lint errors elsewhere in the repository and not caused by these changes.  
- No behavioral / runtime changes to APIs were introduced; this PR is logging/output hygiene only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92f5a4c748330be14a6414ca518af)