### PR TITLE
docs: replace STATUS TODO placeholder with active open work

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -21,7 +21,9 @@ OffMeta is a natural-language search frontend for Magic: The Gathering cards. It
 
 ## Known gaps / TODO
 
-- None at this time.
+- Semantic-search budget fallback test helper debt: `callSemanticSearchWithBudget` is still unimplemented, so budget-based fallback scenarios remain skipped in `supabase/functions/semantic-search/index.test.ts`.
+- Roadmap near/mid-term work still open: combo finder filtering/sorting, deck recommendation sideboard suggestions, and collection management/tracking.
+- Community backlog still open: local Supabase Edge Function contract tests, deployment documentation for Supabase + hosting, and accessibility/keyboard-navigation audit improvements.
 
 ## Recent additions
 


### PR DESCRIPTION
### Motivation
- Replace the placeholder `- None at this time.` in `docs/STATUS.md` with a short, accurate list of currently open work so the status doc reflects known testing debt, roadmap items, and community backlog.

### Description
- Updated `docs/STATUS.md` to list three concise open items: the semantic-search budget-fallback test helper debt (`callSemanticSearchWithBudget`) referenced in `supabase/functions/semantic-search/index.test.ts`, near/mid-term roadmap work (combo finder filtering/sorting, deck-rec sideboard suggestions, collection management), and community backlog items (local Supabase Edge Function contract tests, Supabase+hosting deployment docs, accessibility/keyboard-audit improvements).

### Testing
- No unit or integration test suites were required for this docs-only change; pre-commit hooks (including `prettier`) ran during the commit and succeeded, and the updated file was validated via `sed` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a92f605e1883308b46a6e9d8cebbb0)