### PR TITLE
ci: create GitHub issues automatically when main CI fails

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -28,3 +28,6 @@
 - name: area:infra
   color: fef2c0
   description: CI/CD or tooling
+- name: ci-failure
+  color: bfd4f2
+  description: Automated issue for CI failures on default branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+  issues: write
+
 # Cancel in-progress runs for the same branch/PR
 concurrency:
   group: ci-${{ github.ref }}
@@ -196,3 +200,63 @@ jobs:
         env:
           RUN_SCRYFALL_LIVE_TESTS: '1'
         run: npm run test -- src/lib/scryfall-syntax-validation.test.ts src/lib/scryfall-otag-validation.test.ts
+
+  report-ci-failure:
+    if: ${{ always() && github.ref == 'refs/heads/main' }}
+    needs:
+      - lint
+      - typecheck
+      - test
+      - build
+      - bundle-size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue when CI fails
+        if: ${{ contains(needs.*.result, 'failure') }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const sha = context.sha.slice(0, 7);
+            const title = `CI failure on main (${sha})`;
+            const body = [
+              'Automated CI failure report for `main`.',
+              '',
+              `- Workflow: ${context.workflow}`,
+              `- Run: ${runUrl}`,
+              `- Commit: ${context.sha}`,
+              `- Triggered by: @${context.actor}`,
+              '',
+              '### What to do next',
+              '- [ ] Acknowledge this issue',
+              '- [ ] Investigate failing job(s) in the workflow run',
+              '- [ ] Link the fixing PR and close this issue',
+            ].join('\n');
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'ci-failure',
+              per_page: 100,
+            });
+
+            if (existing.length > 0) {
+              const issue = existing[0];
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Another CI failure detected: ${runUrl} (commit ${context.sha}).`,
+              });
+              core.info(`Updated existing issue #${issue.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['bug', 'area:infra', 'ci-failure'],
+              });
+              core.info(`Created issue #${created.data.number}`);
+            }


### PR DESCRIPTION
### Motivation
- Make CI failures on the `main` branch actionable by automatically creating or updating a GitHub issue so engineers are notified and can triage without manual steps.

### Description
- Add workflow-level `permissions` with `issues: write` so the CI workflow can create and update issues. 
- Add a `report-ci-failure` job in `.github/workflows/ci.yml` that runs on `main`, depends on key jobs, detects failed prerequisite jobs, and either creates a new issue or comments on an existing `ci-failure` issue using `actions/github-script@v7`.
- Create a new `ci-failure` label in `.github/labels.yml` to make automated CI failure issues easy to find and filter.

### Testing
- Parsed both modified YAML files with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); YAML.load_file('.github/labels.yml'); puts 'yaml ok'"` which succeeded. 
- Commit hooks ran and applied `prettier --write` as part of the commit flow, and the changes were committed successfully. 
- Attempted YAML validation with Python (`PyYAML`) but it failed because `PyYAML` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a932c1714c8330b69390665d0c858c)