### PR TITLE
Stabilize index integration loading test

### DIFF
--- a/src/pages/__tests__/Index.integration.test.tsx
+++ b/src/pages/__tests__/Index.integration.test.tsx
@@ -194,8 +194,15 @@ describe('Index page integration', () => {
   });
 
   it('displays skeleton loaders while searching', async () => {
-    // Make translation hang to keep loading state
-    mockTranslateQueryWithDedup.mockImplementation(() => new Promise(() => {}));
+    let resolveTranslation: (() => void) | null = null;
+    mockTranslateQueryWithDedup.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTranslation = () => {
+            resolve(createMockTranslation({ scryfallQuery: 'o:"treasure"' }));
+          };
+        }),
+    );
 
     renderIndex();
 
@@ -211,6 +218,8 @@ describe('Index page integration', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Searching...')).toBeInTheDocument();
     });
+
+    resolveTranslation?.();
   });
 
   it('renders card results after successful search flow', async () => {


### PR DESCRIPTION
### Motivation
- Prevent leaked async work from a never-resolving mock in the `Index` integration test which caused flakiness and cross-test interference.

### Description
- Replace the never-resolving `mockTranslateQueryWithDedup` implementation with a controllable pending promise and explicitly resolve it after asserting the loading UI in `src/pages/__tests__/Index.integration.test.tsx`.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran `npm run test -- src/pages/__tests__/Index.integration.test.tsx` and the updated `Index` integration suite passed (all tests in that file passed).
- Ran the full test suite with `npm run test`, which ran to completion with the updated tests but still reports a pre-existing unrelated runtime error (`ReferenceError: window is not defined`) in `src/lib/i18n/__tests__/locale-detection.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2ebf1af48330ae021c4a4d5e7e79)