### PR TITLE
Improve search latency with warmups, faster cache keys, and better request scheduling

### DIFF
--- a/src/components/AppInitializer.tsx
+++ b/src/components/AppInitializer.tsx
@@ -10,23 +10,55 @@ import { useRealtimeCache } from '@/hooks/useRealtimeCache';
 import { supabase } from '@/integrations/supabase/client';
 
 function useEdgeFunctionWarmup() {
-  const warmedUp = useRef(false);
+  const lastWarmupPath = useRef<string | null>(null);
 
   useEffect(() => {
-    if (warmedUp.current) return;
+    const warmEdgeFunction = () => {
+      const currentPath = `${window.location.pathname}${window.location.search}`;
+      if (lastWarmupPath.current === currentPath) return;
+      lastWarmupPath.current = currentPath;
 
-    const id = setTimeout(() => {
-      if (warmedUp.current) return;
-      warmedUp.current = true;
-
-      supabase.functions
+      void supabase.functions
         .invoke('semantic-search', {
           body: { query: 'ping warmup', useCache: true },
         })
         .catch(() => {});
-    }, 2000);
+    };
 
-    return () => clearTimeout(id);
+    const runWarmupOnReady = () => {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', warmEdgeFunction, {
+          once: true,
+        });
+        return;
+      }
+
+      warmEdgeFunction();
+    };
+
+    runWarmupOnReady();
+
+    const onNavigation = () => warmEdgeFunction();
+
+    window.addEventListener('popstate', onNavigation);
+
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+    history.pushState = (...args) => {
+      originalPushState.apply(history, args);
+      onNavigation();
+    };
+    history.replaceState = (...args) => {
+      originalReplaceState.apply(history, args);
+      onNavigation();
+    };
+
+    return () => {
+      document.removeEventListener('DOMContentLoaded', warmEdgeFunction);
+      window.removeEventListener('popstate', onNavigation);
+      history.pushState = originalPushState;
+      history.replaceState = originalReplaceState;
+    };
   }, []);
 }
 
@@ -48,7 +80,9 @@ function usePrefetchArchetypes() {
         queryFn: async () => {
           const { data, error } = await supabase
             .from('archetype_stats' as 'community_decks')
-            .select('format, macro_archetype, deck_name, archetype, deck_count, meta_percentage, all_colors');
+            .select(
+              'format, macro_archetype, deck_name, archetype, deck_count, meta_percentage, all_colors',
+            );
 
           if (error) throw error;
           return data ?? [];
@@ -108,7 +142,14 @@ function usePrefetchSignatureCards() {
     prefetched.current = true;
 
     const id = setTimeout(() => {
-      for (const format of ['commander', 'modern', 'standard', 'pioneer', 'pauper', 'premodern']) {
+      for (const format of [
+        'commander',
+        'modern',
+        'standard',
+        'pioneer',
+        'pauper',
+        'premodern',
+      ]) {
         queryClient.prefetchQuery({
           queryKey: ['signature-cards', format],
           queryFn: async () => {
@@ -116,9 +157,20 @@ function usePrefetchSignatureCards() {
               target_format: format,
             });
             if (error) throw error;
-            const map = new Map<string, { deckName: string; cardName: string; imageUrl: string }>();
-            for (const row of (data ?? []) as Array<{ deck_name: string; card_name: string; image_url: string }>) {
-              map.set(row.deck_name, { deckName: row.deck_name, cardName: row.card_name, imageUrl: row.image_url });
+            const map = new Map<
+              string,
+              { deckName: string; cardName: string; imageUrl: string }
+            >();
+            for (const row of (data ?? []) as Array<{
+              deck_name: string;
+              card_name: string;
+              image_url: string;
+            }>) {
+              map.set(row.deck_name, {
+                deckName: row.deck_name,
+                cardName: row.card_name,
+                imageUrl: row.image_url,
+              });
             }
             return map;
           },

--- a/src/components/CardItem.tsx
+++ b/src/components/CardItem.tsx
@@ -11,7 +11,10 @@ import type { ScryfallCard } from '@/types/card';
 import { getCardImage } from '@/lib/scryfall/client';
 import { ManaCost } from '@/components/ManaSymbol';
 import { cardNameToSlug } from '@/lib/card-slug';
-import { getLocalizedName, getLocalizedTypeLine } from '@/lib/scryfall/localized';
+import {
+  getLocalizedName,
+  getLocalizedTypeLine,
+} from '@/lib/scryfall/localized';
 import { useTranslation } from '@/lib/i18n';
 
 interface CardItemProps {
@@ -41,7 +44,7 @@ export const CardItem = memo(function CardItem({
   tabIndex = 0,
   isOwned,
 }: CardItemProps) {
-  const imageUrl = getCardImage(card, 'normal');
+  const imageUrl = getCardImage(card, 'small');
   const [imgError, setImgError] = useState(false);
   const { locale } = useTranslation();
   const displayName = getLocalizedName(card, locale);
@@ -68,10 +71,12 @@ export const CardItem = memo(function CardItem({
     >
       {imgError ? (
         <div className="w-full h-full flex items-center justify-center p-4 text-center">
-          <span className="text-sm text-muted-foreground font-medium">{displayName}</span>
+          <span className="text-sm text-muted-foreground font-medium">
+            {displayName}
+          </span>
         </div>
       ) : (
-          <img
+        <img
           src={imageUrl}
           alt={displayName}
           loading="lazy"
@@ -83,8 +88,21 @@ export const CardItem = memo(function CardItem({
 
       {/* Owned badge */}
       {isOwned && (
-        <div className="absolute top-1.5 left-1.5 z-10 h-5 w-5 rounded-full bg-emerald-500/90 flex items-center justify-center shadow-sm" aria-label="Owned">
-          <svg className="h-3 w-3 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+        <div
+          className="absolute top-1.5 left-1.5 z-10 h-5 w-5 rounded-full bg-emerald-500/90 flex items-center justify-center shadow-sm"
+          aria-label="Owned"
+        >
+          <svg
+            className="h-3 w-3 text-white"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <polyline points="20 6 9 17 4 12" />
+          </svg>
         </div>
       )}
 

--- a/src/components/SimilarSearches.tsx
+++ b/src/components/SimilarSearches.tsx
@@ -3,7 +3,7 @@
  * Appears below the ExplainCompilationPanel after a search.
  */
 
-import { memo, useMemo } from 'react';
+import { memo } from 'react';
 import { Link } from 'react-router-dom';
 import { getSimilarSearches } from '@/data/similar-searches';
 import { Search, BookOpen } from 'lucide-react';
@@ -14,51 +14,66 @@ interface SimilarSearchesProps {
   onSuggestionClick: (query: string) => void;
 }
 
-export const SimilarSearches = memo(function SimilarSearches({
-  originalQuery,
-  onSuggestionClick,
-}: SimilarSearchesProps) {
-  const suggestions = useMemo(
-    () => getSimilarSearches(originalQuery),
-    [originalQuery],
-  );
+let lastQuery = '';
+let lastSuggestions = getSimilarSearches('');
 
-  if (suggestions.length === 0) return null;
+function getMemoizedSimilarSearches(query: string) {
+  if (query === lastQuery) return lastSuggestions;
+  lastQuery = query;
+  lastSuggestions = getSimilarSearches(query);
+  return lastSuggestions;
+}
 
-  return (
-    <div className="w-full mx-auto" style={{ maxWidth: 'clamp(320px, 90vw, 672px)' }}>
-      <p className="text-xs text-muted-foreground mb-2 px-1">Similar searches</p>
-      <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-thin">
-        {suggestions.map((s) => (
-          <div key={s.label} className="flex-shrink-0">
-            {s.guidePath ? (
-              <Link
-                to={s.guidePath}
-                className={cn(
-                  'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium',
-                  'border border-border bg-card hover:bg-accent hover:text-accent-foreground',
-                  'transition-colors duration-150 whitespace-nowrap',
-                )}
-              >
-                <BookOpen className="h-3 w-3" />
-                {s.label}
-              </Link>
-            ) : (
-              <button
-                onClick={() => onSuggestionClick(s.query)}
-                className={cn(
-                  'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium',
-                  'border border-border bg-card hover:bg-accent hover:text-accent-foreground',
-                  'transition-colors duration-150 whitespace-nowrap cursor-pointer',
-                )}
-              >
-                <Search className="h-3 w-3" />
-                {s.label}
-              </button>
-            )}
-          </div>
-        ))}
+export const SimilarSearches = memo(
+  function SimilarSearches({
+    originalQuery,
+    onSuggestionClick,
+  }: SimilarSearchesProps) {
+    const suggestions = getMemoizedSimilarSearches(originalQuery);
+
+    if (suggestions.length === 0) return null;
+
+    return (
+      <div
+        className="w-full mx-auto"
+        style={{ maxWidth: 'clamp(320px, 90vw, 672px)' }}
+      >
+        <p className="text-xs text-muted-foreground mb-2 px-1">
+          Similar searches
+        </p>
+        <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-thin">
+          {suggestions.map((s) => (
+            <div key={s.label} className="flex-shrink-0">
+              {s.guidePath ? (
+                <Link
+                  to={s.guidePath}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium',
+                    'border border-border bg-card hover:bg-accent hover:text-accent-foreground',
+                    'transition-colors duration-150 whitespace-nowrap',
+                  )}
+                >
+                  <BookOpen className="h-3 w-3" />
+                  {s.label}
+                </Link>
+              ) : (
+                <button
+                  onClick={() => onSuggestionClick(s.query)}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium',
+                    'border border-border bg-card hover:bg-accent hover:text-accent-foreground',
+                    'transition-colors duration-150 whitespace-nowrap cursor-pointer',
+                  )}
+                >
+                  <Search className="h-3 w-3" />
+                  {s.label}
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
-  );
-});
+    );
+  },
+  (prevProps, nextProps) => prevProps.originalQuery === nextProps.originalQuery,
+);

--- a/src/hooks/useSearchQuery.ts
+++ b/src/hooks/useSearchQuery.ts
@@ -44,6 +44,102 @@ interface TranslationParams {
 // Request deduplication map for in-flight requests
 const pendingTranslations = new Map<string, Promise<TranslationResult>>();
 
+const CROSS_TAB_RESULT_TTL_MS = 5000;
+
+interface TranslationChannelMessage {
+  type: 'translation_started' | 'translation_result';
+  key: string;
+  result?: TranslationResult;
+}
+
+const crossTabPendingKeys = new Set<string>();
+const crossTabResults = new Map<
+  string,
+  { result: TranslationResult; timestamp: number }
+>();
+const crossTabWaiters = new Map<
+  string,
+  Array<(result: TranslationResult) => void>
+>();
+
+const translationBroadcastChannel =
+  typeof window !== 'undefined' && 'BroadcastChannel' in window
+    ? new BroadcastChannel('offmeta-translation-dedup')
+    : null;
+
+translationBroadcastChannel?.addEventListener(
+  'message',
+  (event: MessageEvent<TranslationChannelMessage>) => {
+    const message = event.data;
+    if (!message?.key) return;
+
+    if (message.type === 'translation_started') {
+      crossTabPendingKeys.add(message.key);
+      return;
+    }
+
+    if (message.type === 'translation_result' && message.result) {
+      crossTabPendingKeys.delete(message.key);
+      crossTabResults.set(message.key, {
+        result: message.result,
+        timestamp: Date.now(),
+      });
+
+      const waiters = crossTabWaiters.get(message.key);
+      if (waiters) {
+        waiters.forEach((resolve) =>
+          resolve(message.result as TranslationResult),
+        );
+        crossTabWaiters.delete(message.key);
+      }
+    }
+  },
+);
+
+function getRecentCrossTabResult(key: string): TranslationResult | null {
+  const entry = crossTabResults.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.timestamp > CROSS_TAB_RESULT_TTL_MS) {
+    crossTabResults.delete(key);
+    return null;
+  }
+  return entry.result;
+}
+
+function waitForCrossTabResult(
+  key: string,
+  timeoutMs: number,
+): Promise<TranslationResult | null> {
+  return new Promise((resolve) => {
+    const timeoutId = setTimeout(() => {
+      const waiters = crossTabWaiters.get(key);
+      if (!waiters) {
+        resolve(null);
+        return;
+      }
+
+      const remaining = waiters.filter(
+        (waiter) => waiter !== resolveWithResult,
+      );
+      if (remaining.length > 0) {
+        crossTabWaiters.set(key, remaining);
+      } else {
+        crossTabWaiters.delete(key);
+      }
+      resolve(null);
+    }, timeoutMs);
+
+    const resolveWithResult = (result: TranslationResult) => {
+      clearTimeout(timeoutId);
+      resolve(result);
+    };
+
+    const existing = crossTabWaiters.get(key) ?? [];
+    existing.push(resolveWithResult);
+    crossTabWaiters.set(key, existing);
+  });
+}
+
 /**
  * Generate a cache key for translation requests
  */
@@ -133,6 +229,27 @@ export async function translateQueryWithDedup(
     return pendingTranslations.get(key)!;
   }
 
+  if (!bypassCache) {
+    const recentCrossTabResult = getRecentCrossTabResult(key);
+    if (recentCrossTabResult) {
+      logger.info('[SearchDiag] Cross-tab dedup hit', { query });
+      return recentCrossTabResult;
+    }
+
+    if (crossTabPendingKeys.has(key)) {
+      const sharedResult = await waitForCrossTabResult(key, 1500);
+      if (sharedResult) {
+        logger.info('[SearchDiag] Cross-tab shared result used', { query });
+        return sharedResult;
+      }
+    }
+
+    translationBroadcastChannel?.postMessage({
+      type: 'translation_started',
+      key,
+    } satisfies TranslationChannelMessage);
+  }
+
   const translationPromise = (async () => {
     try {
       // Get session ID for server-side rate limiting
@@ -187,7 +304,7 @@ export async function translateQueryWithDedup(
           edgeResponseTimeMs: data.responseTimeMs ?? null,
         });
 
-        return {
+        const result: TranslationResult = {
           scryfallQuery: data.scryfallQuery,
           explanation: data.explanation,
           showAffiliate: data.showAffiliate,
@@ -197,12 +314,22 @@ export async function translateQueryWithDedup(
           edgeSource,
           edgeResponseTimeMs: data.responseTimeMs,
         };
+
+        crossTabResults.set(key, { result, timestamp: Date.now() });
+        translationBroadcastChannel?.postMessage({
+          type: 'translation_result',
+          key,
+          result,
+        } satisfies TranslationChannelMessage);
+
+        return result;
       }
 
       throw new Error(data?.error || 'Translation failed');
     } finally {
       // Clean up pending request
       pendingTranslations.delete(key);
+      crossTabPendingKeys.delete(key);
     }
   })();
 

--- a/src/lib/scryfall/client.ts
+++ b/src/lib/scryfall/client.ts
@@ -67,86 +67,44 @@ export function clearSearchCache(): void {
 // Rate limiting: Scryfall asks for 50-100ms between requests
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-let lastRequestTime = 0;
 const MIN_REQUEST_INTERVAL = 50; // Scryfall recommends ≥50ms; 100ms was overly conservative
 
-// Request queue for high-traffic scenarios
-interface QueuedRequest {
-  url: string;
-  resolve: (response: Response) => void;
-  reject: (error: Error) => void;
-  timestamp: number; // Added for timeout tracking
-}
-
-const requestQueue: QueuedRequest[] = [];
-let isProcessingQueue = false;
-const MAX_QUEUE_SIZE = 50;
-const QUEUE_ITEM_TIMEOUT_MS = 30000; // 30 second timeout for queued items
-
-/**
- * Process the request queue sequentially with rate limiting.
- * Automatically cleans up timed-out requests.
- */
-async function processQueue(): Promise<void> {
-  if (isProcessingQueue || requestQueue.length === 0) return;
-
-  isProcessingQueue = true;
-
-  while (requestQueue.length > 0) {
-    const request = requestQueue.shift();
-    if (!request) break;
-
-    // Check if request has timed out while waiting in queue
-    if (Date.now() - request.timestamp > QUEUE_ITEM_TIMEOUT_MS) {
-      request.reject(new Error('Request timed out while waiting in queue'));
-      continue;
-    }
-
-    try {
-      const now = Date.now();
-      const timeSinceLastRequest = now - lastRequestTime;
-
-      if (timeSinceLastRequest < MIN_REQUEST_INTERVAL) {
-        await delay(MIN_REQUEST_INTERVAL - timeSinceLastRequest);
-      }
-
-      lastRequestTime = Date.now();
-      const response = await fetchWithRetry(request.url);
-      request.resolve(response);
-    } catch (error) {
-      request.reject(error instanceof Error ? error : new Error(String(error)));
-    }
-  }
-
-  isProcessingQueue = false;
-}
+const MAX_QUEUE_SIZE = 10;
+const QUEUE_ITEM_TIMEOUT_MS = FETCH_TIMEOUT_MS;
+let queuedRequests = 0;
+let nextRequestAllowedAt = 0;
 
 /**
  * Fetch wrapper that enforces Scryfall's rate limiting requirements.
- * Uses a queue to handle concurrent requests during high traffic.
+ * Uses token-bucket style scheduling so requests only delay when needed.
  * @param url - The URL to fetch
  * @returns The fetch Response
  */
 async function rateLimitedFetch(url: string): Promise<Response> {
-  // Clean up any stale timed-out requests before checking size
-  const now = Date.now();
-  while (
-    requestQueue.length > 0 &&
-    now - requestQueue[0].timestamp > QUEUE_ITEM_TIMEOUT_MS
-  ) {
-    const stale = requestQueue.shift();
-    stale?.reject(new Error('Request timed out while waiting in queue'));
-  }
-
-  // If queue is still too long, reject immediately
-  if (requestQueue.length >= MAX_QUEUE_SIZE) {
+  if (queuedRequests >= MAX_QUEUE_SIZE) {
     throw new Error('Too many pending requests. Please try again.');
   }
 
-  return new Promise((resolve, reject) => {
-    requestQueue.push({ url, resolve, reject, timestamp: Date.now() });
-    processQueue();
-  });
+  queuedRequests += 1;
+
+  try {
+    const now = Date.now();
+    const scheduledAt = Math.max(now, nextRequestAllowedAt);
+    const waitMs = scheduledAt - now;
+    nextRequestAllowedAt = scheduledAt + MIN_REQUEST_INTERVAL;
+
+    if (waitMs > QUEUE_ITEM_TIMEOUT_MS) {
+      throw new Error('Request timed out while waiting in queue');
+    }
+
+    if (waitMs > 0) {
+      await delay(waitMs);
+    }
+
+    return await fetchWithRetry(url);
+  } finally {
+    queuedRequests = Math.max(0, queuedRequests - 1);
+  }
 }
 
 async function fetchWithTimeoutWithInit(

--- a/supabase/functions/semantic-search/cache.ts
+++ b/supabase/functions/semantic-search/cache.ts
@@ -27,13 +27,23 @@ export function getCacheKey(
   return `${normalized}|${JSON.stringify(filters || {})}|${cacheSalt || ''}`;
 }
 
-// Cryptographic hash function for cache key using Web Crypto API
-async function hashCacheKey(key: string): Promise<string> {
+// Fast non-cryptographic hash for hot-path in-memory cache logging.
+function hashMemoryCacheKey(key: string): string {
+  let hash = 2166136261; // FNV-1a 32-bit offset basis
+  for (let i = 0; i < key.length; i++) {
+    hash ^= key.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+// Cryptographic hash for persistent database cache key (query_hash column).
+async function hashPersistentCacheKey(key: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(key);
   const hashBuffer = await crypto.subtle.digest('SHA-256', data);
   const hashArray = Array.from(new Uint8Array(hashBuffer));
-  // Return first 16 characters of hex string for reasonable key length
   return hashArray
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
@@ -46,7 +56,7 @@ export async function getCachedResult(
   cacheSalt?: string,
 ): Promise<CacheEntry['result'] | null> {
   const key = getCacheKey(query, filters, cacheSalt);
-  const hash = await hashCacheKey(key);
+  const hash = hashMemoryCacheKey(key);
   const cached = queryCache.get(key);
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
     // LRU touch: delete + re-insert moves entry to end of Map iteration order
@@ -130,7 +140,7 @@ export async function getPersistentCache(
   cacheSalt?: string,
 ): Promise<CacheEntry['result'] | null> {
   const key = getCacheKey(query, filters, cacheSalt);
-  const hash = await hashCacheKey(key);
+  const hash = await hashPersistentCacheKey(key);
 
   try {
     const { data, error } = await supabase
@@ -198,7 +208,7 @@ export async function setPersistentCache(
   if (result.explanation.confidence < 0.65) return;
 
   const key = getCacheKey(query, filters, cacheSalt);
-  const hash = await hashCacheKey(key);
+  const hash = await hashPersistentCacheKey(key);
   const normalized = query.toLowerCase().trim().replace(/\s+/g, ' ');
 
   try {

--- a/supabase/functions/semantic-search/index.ts
+++ b/supabase/functions/semantic-search/index.ts
@@ -148,18 +148,21 @@ async function seedTranslationRule(
     // Don't seed very short or very long queries
     if (normalized.length < 5 || normalized.length > 200) return;
 
-    await supabase.from('translation_rules').insert({
+    await supabase
+      .from('translation_rules')
+      .insert({
         pattern: normalized,
         scryfall_syntax: scryfallQuery,
         confidence,
         description: `Auto-seeded from AI translation`,
         is_active: true,
-      }).then(({ error }) => {
-      // Silently ignore duplicate key conflicts — preserves admin-curated rules
-      if (error && !error.message?.includes('duplicate key')) {
-        console.warn('seedTranslationRule insert error:', error.message);
-      }
-    });
+      })
+      .then(({ error }) => {
+        // Silently ignore duplicate key conflicts — preserves admin-curated rules
+        if (error && !error.message?.includes('duplicate key')) {
+          console.warn('seedTranslationRule insert error:', error.message);
+        }
+      });
   } catch {
     // Silently fail - this is an optimization, not critical
   }
@@ -194,6 +197,21 @@ type StageName =
   | 'fallback';
 
 const ACCENTED_LATIN_HIGH_CONFIDENCE_THRESHOLD = 0.9;
+
+interface EdgeRuntimeLike {
+  waitUntil: (promise: Promise<unknown>) => void;
+}
+
+function runInBackground(task: Promise<unknown>): void {
+  const maybeEdgeRuntime = (globalThis as { EdgeRuntime?: EdgeRuntimeLike })
+    .EdgeRuntime;
+  if (maybeEdgeRuntime?.waitUntil) {
+    maybeEdgeRuntime.waitUntil(task);
+    return;
+  }
+
+  task.catch(() => {});
+}
 
 /**
  * Main Edge Function Handler
@@ -261,7 +279,13 @@ serve(async (req) => {
   const requestBody = parsedBody.requestBody;
 
   try {
-    const { query: rawQuery, filters: rawFilters, debug, useCache, cacheSalt } = requestBody;
+    const {
+      query: rawQuery,
+      filters: rawFilters,
+      debug,
+      useCache,
+      cacheSalt,
+    } = requestBody;
     const query = rawQuery as string;
     const filters = (rawFilters ?? null) as Record<string, unknown> | null;
     const requestBudget = parseRequestBudget(
@@ -728,7 +752,8 @@ serve(async (req) => {
     }
 
     // 6c. Concept Matching (known MTG concepts — skip AI if high-confidence match)
-    const residualForConcepts = deterministicResult.intent.remainingQuery || query;
+    const residualForConcepts =
+      deterministicResult.intent.remainingQuery || query;
     if (residualForConcepts.trim().length > 2) {
       try {
         const { findConceptMatches } = await import('./pipeline/concepts.ts');
@@ -740,7 +765,8 @@ serve(async (req) => {
           const dedupedConcepts = concepts.filter((c) => {
             // Normalize category to prevent near-duplicates
             // e.g., "Mass removal", "Mass removal spells", "Cards that destroy all creatures"
-            const normCat = (c.category || '').toLowerCase()
+            const normCat = (c.category || '')
+              .toLowerCase()
               .replace(/\b(cards?\s+that\s+|spells?\s*)/g, '')
               .trim();
             if (seenCategories.has(normCat)) return false;
@@ -750,14 +776,21 @@ serve(async (req) => {
 
           // Strip color constraints from concept templates when user didn't
           // specify a color (prevents "board whipe" → c:w from "white board wipes")
-          const userSpecifiedColor = deterministicQuery && /\b(c|ci)(:|<=|>=|=|<|>)\S+/i.test(deterministicQuery);
-          const conceptParts = dedupedConcepts.map((c) => {
-            let syntax = c.scryfallSyntax;
-            if (!userSpecifiedColor) {
-              syntax = syntax.replace(/\b(c|ci)(:|<=|>=|=|<|>)\S+/gi, '').replace(/\s+/g, ' ').trim();
-            }
-            return syntax;
-          }).filter(Boolean);
+          const userSpecifiedColor =
+            deterministicQuery &&
+            /\b(c|ci)(:|<=|>=|=|<|>)\S+/i.test(deterministicQuery);
+          const conceptParts = dedupedConcepts
+            .map((c) => {
+              let syntax = c.scryfallSyntax;
+              if (!userSpecifiedColor) {
+                syntax = syntax
+                  .replace(/\b(c|ci)(:|<=|>=|=|<|>)\S+/gi, '')
+                  .replace(/\s+/g, ' ')
+                  .trim();
+              }
+              return syntax;
+            })
+            .filter(Boolean);
 
           let conceptQuery = conceptParts.join(' ');
           if (deterministicQuery) {
@@ -772,20 +805,30 @@ serve(async (req) => {
             concepts: dedupedConcepts.map((c) => c.conceptId),
             responseTimeMs,
           });
-          logInfo('request_completed', getPerfLogFields('pattern_match', responseTimeMs));
+          logInfo(
+            'request_completed',
+            getPerfLogFields('pattern_match', responseTimeMs),
+          );
 
-          const readableDesc = dedupedConcepts.map((c) => c.description || c.conceptId).join(', ');
+          const readableDesc = dedupedConcepts
+            .map((c) => c.description || c.conceptId)
+            .join(', ');
           const conceptIds = dedupedConcepts.map((c) => c.conceptId).join(', ');
 
-          setCachedResult(query, filters, {
-            scryfallQuery: validation.sanitized,
-            explanation: {
-              readable: `Searching for: ${readableDesc}`,
-              assumptions: [`Matched concepts: ${conceptIds}`],
-              confidence: concepts[0].confidence,
+          setCachedResult(
+            query,
+            filters,
+            {
+              scryfallQuery: validation.sanitized,
+              explanation: {
+                readable: `Searching for: ${readableDesc}`,
+                assumptions: [`Matched concepts: ${conceptIds}`],
+                confidence: concepts[0].confidence,
+              },
+              showAffiliate: true,
             },
-            showAffiliate: true,
-          }, cacheSalt);
+            cacheSalt,
+          );
 
           logTranslation(
             query,
@@ -818,7 +861,10 @@ serve(async (req) => {
         }
       } catch (conceptErr) {
         logWarn('concept_match_error', {
-          error: conceptErr instanceof Error ? conceptErr.message : String(conceptErr),
+          error:
+            conceptErr instanceof Error
+              ? conceptErr.message
+              : String(conceptErr),
         });
         // Fall through to AI
       }
@@ -872,7 +918,9 @@ serve(async (req) => {
     const hasAccentedLatin = /[àáâãäåæçèéêëìíîïðñòóôõöùúûüýþÿ]/i.test(
       remainingQuery,
     );
-    const deterministicConfidence = (deterministicResult.intent as unknown as Record<string, unknown>).confidence as number ?? 0;
+    const deterministicConfidence =
+      ((deterministicResult.intent as unknown as Record<string, unknown>)
+        .confidence as number) ?? 0;
     const shouldPreTranslateAccentedLatin =
       hasAccentedLatin &&
       !hasNonLatin &&
@@ -977,7 +1025,12 @@ serve(async (req) => {
           .trim();
 
         // Skip if too short or looks like a generic type
-        if (candidateName.length >= 3 && !/^(creatures?|artifacts?|enchantments?|lands?|instants?|sorcery|sorceries|spells?|planeswalkers?)$/i.test(candidateName)) {
+        if (
+          candidateName.length >= 3 &&
+          !/^(creatures?|artifacts?|enchantments?|lands?|instants?|sorcery|sorceries|spells?|planeswalkers?)$/i.test(
+            candidateName,
+          )
+        ) {
           try {
             const cardLookup = await fetchWithTimeout(
               `https://api.scryfall.com/cards/named?fuzzy=${encodeURIComponent(candidateName)}`,
@@ -988,7 +1041,8 @@ serve(async (req) => {
               const cardData = await cardLookup.json();
               if (cardData.oracle_text && cardData.name) {
                 detectedCardName = cardData.name;
-                const colorId = cardData.color_identity?.join('').toLowerCase() || '';
+                const colorId =
+                  cardData.color_identity?.join('').toLowerCase() || '';
                 cardSynergyContext = `\n\nCARD CONTEXT: The user is looking for cards that synergize with "${cardData.name}" (${cardData.type_line}). Its oracle text is: "${cardData.oracle_text}". Color identity: ${colorId || 'colorless'}. Generate a Scryfall query for cards that ENABLE or SYNERGIZE with this card's mechanics. Use id<=${colorId || 'c'} if the query implies commander format. Do NOT put the card name in o:"" — other cards don't mention this card by name.`;
                 logInfo('card_synergy_detected', {
                   cardName: cardData.name,
@@ -1010,16 +1064,21 @@ serve(async (req) => {
     const isLikelyName =
       deterministicResult.intent.warnings.includes('likely_card_name');
     // Use medium tier for synergy queries since they need more reasoning
-    const tier: QueryTier =
-      cardSynergyContext ? 'medium' :
-      queryWordCount > 8 ? 'complex' : queryWordCount > 4 ? 'medium' : 'simple';
+    const tier: QueryTier = cardSynergyContext
+      ? 'medium'
+      : queryWordCount > 8
+        ? 'complex'
+        : queryWordCount > 4
+          ? 'medium'
+          : 'simple';
 
     // Use stronger model for card name queries or synergy queries
-    const aiModel = isLikelyName || cardSynergyContext
-      ? 'google/gemini-2.5-flash'
-      : tier === 'simple'
-        ? 'google/gemini-2.5-flash-lite'
-        : 'google/gemini-3-flash-preview';
+    const aiModel =
+      isLikelyName || cardSynergyContext
+        ? 'google/gemini-2.5-flash'
+        : tier === 'simple'
+          ? 'google/gemini-2.5-flash-lite'
+          : 'google/gemini-3-flash-preview';
 
     // Deterministic fallback guard: skip optional dynamic rules if remaining budget
     // drops below the stage floor derived from REQUEST_BUDGET_MS.
@@ -1128,8 +1187,8 @@ serve(async (req) => {
 
       // Auto-seed high-confidence AI translations into translation_rules for future pattern matches
       if (confidence >= 0.8 && validation.sanitized.length > 0) {
-        seedTranslationRule(query, validation.sanitized, confidence).catch(
-          () => {},
+        runInBackground(
+          seedTranslationRule(query, validation.sanitized, confidence),
         );
       }
 

--- a/supabase/functions/semantic-search/rules.ts
+++ b/supabase/functions/semantic-search/rules.ts
@@ -1,5 +1,47 @@
 import { supabase } from './client.ts';
 
+interface StaticRule {
+  pattern: string;
+  scryfall_syntax: string;
+  description?: string;
+}
+
+const STATIC_DYNAMIC_RULES: StaticRule[] = (() => {
+  const raw = Deno.env.get('STATIC_TRANSLATION_RULES_JSON');
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed
+      .filter(
+        (item): item is StaticRule =>
+          typeof item?.pattern === 'string' &&
+          typeof item?.scryfall_syntax === 'string' &&
+          (typeof item?.description === 'string' || item?.description == null),
+      )
+      .slice(0, 20);
+  } catch {
+    return [];
+  }
+})();
+
+function formatRules(rules: StaticRule[]): string {
+  if (rules.length === 0) return '';
+
+  const rulesText = rules
+    .map(
+      (r) =>
+        `- "${r.pattern}" → ${r.scryfall_syntax}${r.description ? ` (${r.description})` : ''}`,
+    )
+    .join('\n');
+
+  return `\n\nDYNAMIC RULES (learned from user feedback - PRIORITIZE these):\n${rulesText}`;
+}
+
+const STATIC_RULES_TEXT = formatRules(STATIC_DYNAMIC_RULES);
+
 // In-memory cache for dynamic rules
 let dynamicRulesCache: { rules: string; timestamp: number } | null = null;
 const DYNAMIC_RULES_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
@@ -10,6 +52,11 @@ const DYNAMIC_RULES_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
  * These rules are generated from user feedback to improve translations.
  */
 export async function fetchDynamicRules(): Promise<string> {
+  // Prefer statically baked rules to remove DB latency from the hot path.
+  if (STATIC_RULES_TEXT) {
+    return STATIC_RULES_TEXT;
+  }
+
   // Check cache first
   if (
     dynamicRulesCache &&
@@ -33,14 +80,7 @@ export async function fetchDynamicRules(): Promise<string> {
       return '';
     }
 
-    const rulesText = rules
-      .map(
-        (r) =>
-          `- "${r.pattern}" → ${r.scryfall_syntax}${r.description ? ` (${r.description})` : ''}`,
-      )
-      .join('\n');
-
-    const result = `\n\nDYNAMIC RULES (learned from user feedback - PRIORITIZE these):\n${rulesText}`;
+    const result = formatRules(rules);
 
     // Cache the result
     dynamicRulesCache = { rules: result, timestamp: Date.now() };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,14 +61,13 @@ export default defineConfig(({ mode }) => ({
           },
           {
             urlPattern: /^https:\/\/api\.scryfall\.com\/.*/i,
-            handler: 'NetworkFirst',
+            handler: 'StaleWhileRevalidate',
             options: {
               cacheName: 'scryfall-api',
               expiration: {
                 maxEntries: 100,
-                maxAgeSeconds: 60 * 5, // 5 minutes
+                maxAgeSeconds: 60 * 15, // 15 minutes
               },
-              networkTimeoutSeconds: 10,
               cacheableResponse: {
                 statuses: [0, 200],
               },


### PR DESCRIPTION
### Motivation

- Reduce first-search latency by avoiding Supabase Edge Function cold starts and eliminate unnecessary async work on the hot path. 
- Remove artificial serialization and wasted async overhead in client and edge caches to make parallel requests and cache lookups faster.
- Reduce bandwidth and unnecessary re-renders in result grids and suggestions for a snappier UX.

### Description

- Warmup: `useEdgeFunctionWarmup` now fires immediately on `DOMContentLoaded` and re-warms the `semantic-search` function on client-side navigation (`pushState`/`replaceState`/`popstate`) to reduce cold-start hits. (`src/components/AppInitializer.tsx`)
- Cache hashing: split cache hashing into a fast synchronous FNV-1a (`hashMemoryCacheKey`) for in-memory hot-path lookups/logging and a SHA-256 (`hashPersistentCacheKey`) only for persistent DB `query_cache` reads/writes. (`supabase/functions/semantic-search/cache.ts`)
- Background seeding: defer `seedTranslationRule` using `runInBackground` which uses `EdgeRuntime.waitUntil()` when available, preventing seeding from adding tail latency to responses. (`supabase/functions/semantic-search/index.ts`)
- Static dynamic rules: support optional baked rules via `STATIC_TRANSLATION_RULES_JSON` and prefer static rules in `fetchDynamicRules()` to avoid the DB round-trip on the hot path. (`supabase/functions/semantic-search/rules.ts`)
- Request scheduling: replace the single sequential Scryfall request queue with a token-bucket–style scheduler that only waits when necessary, reduce `MAX_QUEUE_SIZE` to 10, and align queue wait timeout with client fetch timeout (`FETCH_TIMEOUT_MS`). (`src/lib/scryfall/client.ts`)
- Cross-tab dedup: add a `BroadcastChannel` based cross-tab deduplication for in-flight/completed translations so simultaneous searches across tabs share results. (`src/hooks/useSearchQuery.ts`)
- Rendering/UX: use `small` card images in grid views (`CardItem`) to cut image payload, and add a stable module-level 1-entry memoization + explicit `React.memo` comparator for `SimilarSearches` to avoid unnecessary recomputation/rerenders. (`src/components/CardItem.tsx`, `src/components/SimilarSearches.tsx`)
- PWA: change Scryfall API runtime caching to `StaleWhileRevalidate` and increase TTL from 5 minutes to 15 minutes to serve repeat search results faster offline/slow networks. (`vite.config.ts`)

### Testing

- Ran focused unit tests with `npm run test -- src/hooks/__tests__/useSearchQuery.test.ts src/lib/config.test.ts` which passed. 
- Ran the full test suite with `npm run test` and all automated tests completed successfully in this environment. 
- Verified production build with `npm run build` completed successfully and started the dev server for an end-to-end smoke check (page load and search screenshot captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11bdb6f50833084c792ddb8174461)