### PR TITLE
Stabilize Scryfall rulings cache test mocks

### DIFF
--- a/src/lib/scryfall/client.test.ts
+++ b/src/lib/scryfall/client.test.ts
@@ -250,8 +250,9 @@ describe('scryfall client', () => {
           ],
         }),
       )
-      .mockResolvedValueOnce(mockResponse({ object: 'error' }, 500))
-      .mockRejectedValueOnce(new Error('Network error'));
+      .mockResolvedValueOnce(mockResponse({ object: 'error' }, 400))
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValue(mockResponse({ object: 'error' }, 400));
 
     const consoleSpy = vi
       .spyOn(console, 'error')


### PR DESCRIPTION
### Motivation
- Prevent intermittent timeouts in the `getCardRulings` test by keeping all `fetch` calls deterministic and avoiding exhaustion of one-time mocks that could fall through to real network requests.

### Description
- In `src/lib/scryfall/client.test.ts` changed the bad-response mock from a retried `500` to a non-retried `400` and added a persistent `.mockResolvedValue(...)` fallback so the test's retry logic cannot exhaust the mocks and trigger real network behavior.

### Testing
- Ran `npm run test -- src/lib/scryfall/client.test.ts --reporter=verbose` and the file's tests passed (13/13 tests successful).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3a870d0a88330adb61237c2457486)