### PR TITLE
i18n: localize refinement and Pro upsell banners on search results

### DIFF
--- a/src/lib/i18n/de.json
+++ b/src/lib/i18n/de.json
@@ -888,6 +888,8 @@
   "results.adjustFilters": "Versuche, deine Filterkriterien anzupassen.",
   "results.cards": "Karten",
   "results.cardsTotal": "{count} Karten insgesamt",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "Ende erreicht · {count} Karten insgesamt",
   "results.fallbackLangNotice": "Ergebnisse auf Englisch — nicht alle Karten sind in dieser Sprache verfügbar.",
   "results.loadingMore": "Weitere Karten werden geladen...",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -57,6 +57,8 @@
   "results.loadingMore": "Loading more cards...",
   "results.endMessage": "You've reached the end · {count} cards total",
   "results.cardsTotal": "{count} cards total",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "empty.noCards": "No cards found",
   "empty.noMatch": "We couldn't find any cards matching",
   "empty.tips": "Search tips",

--- a/src/lib/i18n/es.json
+++ b/src/lib/i18n/es.json
@@ -890,6 +890,8 @@
   "results.adjustFilters": "Intenta ajustar tus criterios de filtro.",
   "results.cards": "cartas",
   "results.cardsTotal": "{count} cartas en total",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "Has llegado al final · {count} cartas en total",
   "results.fallbackLangNotice": "Mostrando resultados en inglés — no todas las cartas están disponibles en este idioma.",
   "results.loadingMore": "Cargando más cartas...",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -890,6 +890,8 @@
   "results.adjustFilters": "Essayez d'ajuster vos critères de filtre.",
   "results.cards": "cartes",
   "results.cardsTotal": "{count} cartes au total",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "Vous avez atteint la fin · {count} cartes au total",
   "results.fallbackLangNotice": "Affichage des résultats en anglais — toutes les cartes ne sont pas disponibles dans cette langue.",
   "results.loadingMore": "Chargement de plus de cartes...",

--- a/src/lib/i18n/it.json
+++ b/src/lib/i18n/it.json
@@ -888,6 +888,8 @@
   "results.adjustFilters": "Prova a modificare i criteri di filtro.",
   "results.cards": "carte",
   "results.cardsTotal": "{count} carte in totale",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "Hai raggiunto la fine · {count} carte in totale",
   "results.fallbackLangNotice": "Risultati in inglese — non tutte le carte sono disponibili in questa lingua.",
   "results.loadingMore": "Caricamento altre carte...",

--- a/src/lib/i18n/ja.json
+++ b/src/lib/i18n/ja.json
@@ -888,6 +888,8 @@
   "results.adjustFilters": "フィルター条件を調整してみてください。",
   "results.cards": "枚のカード",
   "results.cardsTotal": "合計{count}枚",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "最後まで到達しました · 合計{count}枚",
   "results.fallbackLangNotice": "英語の結果を表示しています — すべてのカードがこの言語で利用できるわけではありません。",
   "results.loadingMore": "さらにカードを読み込み中...",

--- a/src/lib/i18n/ko.json
+++ b/src/lib/i18n/ko.json
@@ -917,6 +917,8 @@
   "results.adjustFilters": "필터 기준을 조정해 보세요.",
   "results.cards": "장의 카드",
   "results.cardsTotal": "총 {count}장",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "끝에 도달했습니다 · 총 {count}장",
   "results.fallbackLangNotice": "영어 결과를 표시합니다 — 모든 카드가 이 언어로 제공되지는 않습니다.",
   "results.loadingMore": "카드 더 불러오는 중...",

--- a/src/lib/i18n/pt.json
+++ b/src/lib/i18n/pt.json
@@ -888,6 +888,8 @@
   "results.adjustFilters": "Tente ajustar seus critérios de filtro.",
   "results.cards": "cartas",
   "results.cardsTotal": "{count} cartas no total",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "Você chegou ao fim · {count} cartas no total",
   "results.fallbackLangNotice": "Mostrando resultados em inglês — nem todas as cartas estão disponíveis neste idioma.",
   "results.loadingMore": "Carregando mais cartas...",

--- a/src/lib/i18n/ru.json
+++ b/src/lib/i18n/ru.json
@@ -917,6 +917,8 @@
   "results.adjustFilters": "Попробуйте изменить критерии фильтра.",
   "results.cards": "карт",
   "results.cardsTotal": "всего {count} карт",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "Вы достигли конца · всего {count} карт",
   "results.fallbackLangNotice": "Показаны результаты на английском — не все карты доступны на этом языке.",
   "results.loadingMore": "Загрузка дополнительных карт...",

--- a/src/lib/i18n/zhs.json
+++ b/src/lib/i18n/zhs.json
@@ -917,6 +917,8 @@
   "results.adjustFilters": "请尝试调整筛选条件。",
   "results.cards": "张卡牌",
   "results.cardsTotal": "共 {count} 张",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "已到达末尾 · 共 {count} 张",
   "results.fallbackLangNotice": "显示英文结果 — 并非所有卡牌都有此语言版本。",
   "results.loadingMore": "正在加载更多卡牌...",

--- a/src/lib/i18n/zht.json
+++ b/src/lib/i18n/zht.json
@@ -917,6 +917,8 @@
   "results.adjustFilters": "請嘗試調整篩選條件。",
   "results.cards": "張卡牌",
   "results.cardsTotal": "共 {count} 張",
+  "results.search.refinementUpsell": "Narrow results like this? Save this refinement as a reusable workflow.",
+  "results.search.proUpsell": "Better results with Pro: advanced explainability + priority ranking.",
   "results.endMessage": "已到達末尾 · 共 {count} 張",
   "results.fallbackLangNotice": "顯示英文結果 — 並非所有卡牌都有此語言版本。",
   "results.loadingMore": "正在載入更多卡牌...",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -522,14 +522,18 @@ const Index = () => {
               <div className="space-y-2">
                 {refinementCount > 0 && (
                   <div className="rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-foreground">
-                    Narrow results like this? Save this refinement as a reusable
-                    workflow.
+                    {t(
+                      'results.search.refinementUpsell',
+                      'Narrow results like this? Save this refinement as a reusable workflow.',
+                    )}
                   </div>
                 )}
                 {shouldShowProUpsell && (
                   <div className="rounded-lg border border-primary/30 bg-primary/10 px-3 py-2 text-xs text-foreground">
-                    Better results with Pro: advanced explainability + priority
-                    ranking.
+                    {t(
+                      'results.search.proUpsell',
+                      'Better results with Pro: advanced explainability + priority ranking.',
+                    )}
                   </div>
                 )}
               </div>
@@ -651,8 +655,6 @@ const Index = () => {
           open={compareOpen}
           onClose={closeCompare}
         />
-
-        
       </div>
     </ErrorBoundary>
   );


### PR DESCRIPTION
### Motivation
- Make the small informational banners on search results localizable so they can be translated into other locales. 
- Preserve the exact existing copy as inline fallbacks to avoid behavioral or visual regressions when a translation key is missing.

### Description
- Replaced the two hardcoded banner strings in `src/pages/Index.tsx` with `t(...)` lookups using keys `results.search.refinementUpsell` and `results.search.proUpsell` while passing the original text as the fallback. 
- Added the new keys to all locale files under `src/lib/i18n/*.json` so each locale has the entry present. 
- Left the gating/conditional rendering logic unchanged (`refinementCount > 0` and `shouldShowProUpsell` remain as before).

### Testing
- Ran `npm run test -- src/lib/i18n/__tests__/i18n-provider.test.tsx` and all tests passed. 
- Verified JSON dictionaries parse by running a Node JSON parse check (`node -e ...`) which completed successfully. 
- Confirmed formatting/linting tasks executed during commit (prettier and eslint) without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dccb262e208330b586c93a823bf514)